### PR TITLE
fix: debug parser no overseer dir error

### DIFF
--- a/lua/overseer/parser/debug.lua
+++ b/lua/overseer/parser/debug.lua
@@ -152,6 +152,10 @@ M.start_debug_session = function()
       vim.api.nvim_buf_delete(buf, { force = true })
     end
   end
+  local overseer_dir = files.join(vim.fn.stdpath("cache"), "overseer")
+  if vim.fn.isdirectory(overseer_dir) == 0 then
+    vim.fn.mkdir(overseer_dir)
+  end
   vim.cmd([[tabnew]])
   create_source_bufnr()
   local source_win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
## Problem
If the user did not have an 'overseer' directory in their cache, the debug parser would fail to start.

## Fix
Check if the user has an 'overseer' directory, and if not, create one before running the debug session.