### PR TITLE
fix: add compatibility for neotest test file run

### DIFF
--- a/lua/neotest/consumers/overseer.lua
+++ b/lua/neotest/consumers/overseer.lua
@@ -12,6 +12,10 @@ local task_groups = {}
 
 function neotest.overseer.run(args)
   args = args or {}
+  if type(args) == "string" then
+    args = { args }
+  end
+
   if args.strategy and args.strategy ~= "overseer" then
     return neotest.run.run(args)
   else


### PR DESCRIPTION
To run test file, the example given in Neotest is :

`require("neotest").run.run(vim.fn.expand("%"))`

The `args` parameter is therefore a `string` and it is not compatible with Overseer consumer.
This PR fixes this issue.