### PR TITLE
fix: link to actions.lua in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ Providers are created the same way templates are (with `overseer.register_templa
 
 Actions can be performed on tasks by using the `RunAction` keybinding in the task list, or by the `OverseerQuickAction` and `OverseerTaskAction` commands. They are simply a custom function that will do something to or with a task.
 
-Browse the set of built-in actions at [lua/overseer/task_list/actions.lua](../lua/overseer/task_list/actions.lua)
+Browse the set of built-in actions at [lua/overseer/task_list/actions.lua](lua/overseer/task_list/actions.lua)
 
 You can define your own or disable any of the built-in actions in the call to setup():
 


### PR DESCRIPTION
## Problem
The link to the built-in actions (in `actions.lua`) was broken and led to an invalid page.

## Fix
Fix the invalid link by removing the part that caused the problem.