### PR TITLE
feat(cargo): change conditional callback function

### DIFF
--- a/lua/overseer/template/cargo.lua
+++ b/lua/overseer/template/cargo.lua
@@ -23,7 +23,7 @@ local tmpl = {
 return {
   condition = {
     callback = function(opts)
-      return files.exists(files.join(opts.dir, "Cargo.toml"))
+      return files.exists(vim.fn.findfile("Cargo.toml", opts.dir .. ";"))
     end,
   },
   generator = function(opts)


### PR DESCRIPTION
Checks for existence of `Cargo.toml` in parent directories rather than just `opts.dir`. This allows the user to be editing any file in a Rust project and use `cargo` commands from Overseer. Fixes #24. Let me know if anything else needs to be changed!