### PR TITLE
feat(summary): Skip [Process exited] in summary

### DIFF
--- a/lua/overseer/component/on_output_summarize.lua
+++ b/lua/overseer/component/on_output_summarize.lua
@@ -56,12 +56,19 @@ return {
       render = function(self, task, lines, highlights, detail)
         local prefix = "out: "
         if detail == 1 then
-          local last_line = self.lines[#self.lines]
-          if last_line and last_line ~= "" then
-            table.insert(lines, prefix .. last_line)
-            table.insert(highlights, { "Comment", #lines, 0, 4 })
-            table.insert(highlights, { "OverseerOutput", #lines, 4, -1 })
+          local i = #lines
+          while
+            not vim.tbl_isempty(lines)
+            and (lines[#lines] == "" or lines[#lines]:match("^%[Process exited"))
+          do
+            i = i - 1
           end
+          if not self.lines[i] then
+            return
+          end
+          table.insert(lines, prefix .. self.lines[i])
+          table.insert(highlights, { "Comment", #lines, 0, 4 })
+          table.insert(highlights, { "OverseerOutput", #lines, 4, -1 })
         else
           for _, line in ipairs(self.lines) do
             table.insert(lines, prefix .. line)


### PR DESCRIPTION
With the latest commit, the Overseer sidebar now displays the helpful
summary of the tast. But for a shell command of c++ compile commands,
the last line is always [Process extied err_code] which is not helpful
because the task exit notification already states if it was success or
failure. This PR just gets the next non_empty line from the bottom