### PR TITLE
add elixir mix support

### DIFF
--- a/lua/overseer/template/builtin.lua
+++ b/lua/overseer/template/builtin.lua
@@ -1,1 +1,1 @@
-return { "cargo", "just", "make", "npm", "shell", "tox", "vscode" }
+return { "cargo", "just", "make", "npm", "shell", "tox", "vscode", "mix" }

--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -1,0 +1,61 @@
+local files = require("overseer.files")
+local overseer = require("overseer")
+local log = require("overseer.log")
+
+---@type overseer.TemplateDefinition
+local tmpl = {
+  priority = 60,
+  params = {
+    args = { optional = true, type = "list", delimiter = " " },
+  },
+  builder = function(params)
+    local cmd = { "mix" }
+    if params.args then
+      cmd = vim.list_extend(cmd, params.args)
+    end
+    return {
+      cmd = cmd,
+    }
+  end,
+}
+
+return {
+  condition = {
+    callback = function(opts)
+      return files.exists(files.join(opts.dir, "mix.exs"))
+    end,
+  },
+  generator = function(opts, cb)
+    local ret = {}
+    local jid = vim.fn.jobstart({
+      "mix",
+      "help",
+    }, {
+      cwd = opts.dir,
+      stdout_buffered = true,
+      on_stdout = vim.schedule_wrap(function(j, output)
+        for _, line in ipairs(output) do
+          local task_name = line:match("mix (%S+)%s")
+          table.insert(
+            ret,
+            overseer.wrap_template(
+              tmpl,
+              { name = string.format("mix %s", task_name) },
+              { args = { task_name } }
+            )
+          )
+        end
+      end),
+      on_exit = vim.schedule_wrap(function(j, output)
+        cb(ret)
+      end),
+    })
+    if jid == 0 then
+      log:error("Passed invalid arguments to 'mix'")
+      cb(ret)
+    elseif jid == -1 then
+      log:error("'mix' is not executable")
+      cb(ret)
+    end
+  end,
+}


### PR DESCRIPTION
first off, thank you very much for this plugin, it really great! much appreciated!

i've written some integration for the elixir mix system. the contents of the elixir files is elixir code, so it's not possible to parse it from lua, the only way to list the tasks is to run `mix help`. The downside is that that takes a little bit of time to run the help, so that slows down the display a little, but there's no other way that i can think of.