### PR TITLE
feat: add quickfix keybind

### DIFF
--- a/doc/overseer.txt
+++ b/doc/overseer.txt
@@ -91,6 +91,7 @@ OPTIONS                                                         *overseer-option
           ["o"] = "Open",
           ["<C-v>"] = "OpenVsplit",
           ["<C-s>"] = "OpenSplit",
+          ["<C-q>"] = "OpenQuickFix",
           ["<C-f>"] = "OpenFloat",
           ["p"] = "TogglePreview",
           ["<C-l>"] = "IncreaseDetail",

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -87,6 +87,7 @@ require("overseer").setup({
       ["<C-v>"] = "OpenVsplit",
       ["<C-s>"] = "OpenSplit",
       ["<C-f>"] = "OpenFloat",
+      ["<C-q>"] = "OpenQuickFix",
       ["p"] = "TogglePreview",
       ["<C-l>"] = "IncreaseDetail",
       ["<C-h>"] = "DecreaseDetail",

--- a/lua/overseer/config.lua
+++ b/lua/overseer/config.lua
@@ -34,6 +34,7 @@ local default_config = {
       ["<C-v>"] = "OpenVsplit",
       ["<C-s>"] = "OpenSplit",
       ["<C-f>"] = "OpenFloat",
+      ["<C-q>"] = "OpenQuickFix",
       ["p"] = "TogglePreview",
       ["<C-l>"] = "IncreaseDetail",
       ["<C-h>"] = "DecreaseDetail",

--- a/lua/overseer/task_list/bindings.lua
+++ b/lua/overseer/task_list/bindings.lua
@@ -51,6 +51,13 @@ M = {
     end,
   },
   {
+    desc = "Open task output in a quickfix window",
+    plug = "<Plug>OverseerTask:OpenQuickFix",
+    rhs = function(sidebar)
+      sidebar:run_action("open output in quickfix")
+    end,
+  },
+  {
     desc = "Toggle task terminal in a preview window",
     plug = "<Plug>OverseerTask:TogglePreview",
     rhs = function(sidebar)


### PR DESCRIPTION
Currently there is no binding for opening the output in the quickfix window, you have to navigate to the actions menu and select the quickfix option. This will add a binding (default <C-q>) to open the quickfix window from the task list.