### PR TITLE
Adds the 'toggleterm' strategy

### DIFF
--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -116,7 +116,7 @@ function ToggleTermStrategy:start(task)
   elseif chan_id == -1 then
     error(string.format("Command '%s' not executable", vim.inspect(task.cmd)))
   else
-    jobs.unregister(chan_id)
+    jobs.register(chan_id)
     self.chan_id = chan_id
   end
 end

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -42,7 +42,6 @@ function ToggleTermStrategy:start(task)
   local stdout_iter = util.get_stdout_line_iter()
 
   local function on_stdout(data)
-    log:debug("Provided output %s", data)
     task:dispatch("on_output", data)
     local lines = stdout_iter(data)
     if not vim.tbl_isempty(lines) then
@@ -66,19 +65,12 @@ function ToggleTermStrategy:start(task)
       if self.chan_id ~= j then
         return
       end
-      log:debug("Task %s exited with code %s", task.name, c)
       -- Feed one last line end to flush the output
       on_stdout({ "" })
       self.chan_id = nil
-      -- If we're exiting vim, don't call the on_exit handler
-      -- We manually kill processes during VimLeavePre cleanup, and we don't want to trigger user
-      -- code because of that
       if vim.v.exiting == vim.NIL then
         task:on_exit(c)
       end
-    end,
-    on_close = function(_)
-      log:debug("Closing terminal")
     end,
     auto_scroll = true,
     close_on_exit = false,

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -1,18 +1,9 @@
-local log = require("overseer.log")
 local jobs = require("overseer.strategy._jobs")
 local util = require("overseer.util")
 
 local terminal = require('toggleterm.terminal')
 
 local ToggleTermStrategy = {}
-
-local function with_cr(...)
-  local result = {}
-  for _, str in ipairs({ ... }) do
-    table.insert(result, str .. " ")
-  end
-  return table.concat(result, "")
-end
 
 ---@return overseer.Strategy
 function ToggleTermStrategy.new()
@@ -49,7 +40,7 @@ function ToggleTermStrategy:start(task)
     end
   end
 
-  local cmd = type(task.cmd) == "table" and with_cr(unpack(task.cmd)) or with_cr(task.cmd)
+  local cmd = type(task.cmd) == "table" and unpack(task.cmd) or task.cmd
   local term = terminal.Terminal:new({
     cmd = cmd,
     cwd = task.cwd,

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -40,7 +40,12 @@ function ToggleTermStrategy:start(task)
     end
   end
 
-  local cmd = type(task.cmd) == "table" and unpack(task.cmd) or task.cmd
+
+  local cmd = task.cmd
+  if type(task.cmd) == "table" then
+    cmd = table.concat(vim.tbl_map(vim.fn.shellescape, task.cmd), " ")
+  end
+
   local term = terminal.Terminal:new({
     cmd = cmd,
     cwd = task.cwd,

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -1,26 +1,26 @@
 local jobs = require("overseer.strategy._jobs")
 local util = require("overseer.util")
 
-local terminal = require('toggleterm.terminal')
+local terminal = require("toggleterm.terminal")
 
 local ToggleTermStrategy = {}
 
 ---@return overseer.Strategy
 function ToggleTermStrategy.new(opts)
   opts = vim.tbl_extend("keep", opts or {}, {
-    use_shell = false,     -- load user shell before running task
-    direction = nil,       -- "vertical" | "horizontal" | "tab" | "float"
-    dir = nil,             -- open ToggleTerm at specified directory before task
-    highlights = nil,      -- map to a highlight group name and a table of it's values
-    auto_scroll = nil,     -- automatically scroll to the bottom on task output
+    use_shell = false, -- load user shell before running task
+    direction = nil, -- "vertical" | "horizontal" | "tab" | "float"
+    dir = nil, -- open ToggleTerm at specified directory before task
+    highlights = nil, -- map to a highlight group name and a table of it's values
+    auto_scroll = nil, -- automatically scroll to the bottom on task output
     close_on_exit = false, -- close the terminal (if open) after task exits
-    open_on_start = true,  -- toggle open the terminal automatically when task starts
-    hidden = false         -- cannot be toggled with normal ToggleTerm commands
+    open_on_start = true, -- toggle open the terminal automatically when task starts
+    hidden = false, -- cannot be toggled with normal ToggleTerm commands
   })
   return setmetatable({
     bufnr = nil,
     chan_id = nil,
-    opts = opts
+    opts = opts,
   }, { __index = ToggleTermStrategy })
 end
 
@@ -50,7 +50,6 @@ function ToggleTermStrategy:start(task)
       task:dispatch("on_output_lines", lines)
     end
   end
-
 
   local cmd = task.cmd
   if type(task.cmd) == "table" then

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -1,0 +1,115 @@
+local log = require("overseer.log")
+local jobs = require("overseer.strategy._jobs")
+local util = require("overseer.util")
+
+local terminal = require('toggleterm.terminal')
+
+local ToggleTermStrategy = {}
+
+local function with_cr(...)
+  local result = {}
+  for _, str in ipairs({ ... }) do
+    table.insert(result, str .. " ")
+  end
+  return table.concat(result, "")
+end
+
+---@return overseer.Strategy
+function ToggleTermStrategy.new()
+  return setmetatable({
+    bufnr = nil,
+    chan_id = nil,
+  }, { __index = ToggleTermStrategy })
+end
+
+function ToggleTermStrategy:reset()
+  util.soft_delete_buf(self.bufnr)
+  self.bufnr = nil
+  if self.chan_id then
+    vim.fn.jobstop(self.chan_id)
+    self.chan_id = nil
+  end
+end
+
+function ToggleTermStrategy:get_bufnr()
+  return self.bufnr
+end
+
+---@param task overseer.Task
+function ToggleTermStrategy:start(task)
+  local chan_id
+  local mode = vim.api.nvim_get_mode().mode
+  local stdout_iter = util.get_stdout_line_iter()
+
+  local function on_stdout(data)
+    log:debug("Provided output %s", data)
+    task:dispatch("on_output", data)
+    local lines = stdout_iter(data)
+    if not vim.tbl_isempty(lines) then
+      task:dispatch("on_output_lines", lines)
+    end
+  end
+
+  local cmd = type(task.cmd) == "table" and with_cr(unpack(task.cmd)) or with_cr(task.cmd)
+  local term = terminal.Terminal:new({
+    cmd = cmd,
+    cwd = task.cwd,
+    env = task.env,
+    on_stdout = function(j, d)
+      if self.chan_id ~= j then
+        return
+      end
+      on_stdout(d)
+    end,
+    on_exit = function(_, j, c)
+      jobs.unregister(j)
+      if self.chan_id ~= j then
+        return
+      end
+      log:debug("Task %s exited with code %s", task.name, c)
+      -- Feed one last line end to flush the output
+      on_stdout({ "" })
+      self.chan_id = nil
+      -- If we're exiting vim, don't call the on_exit handler
+      -- We manually kill processes during VimLeavePre cleanup, and we don't want to trigger user
+      -- code because of that
+      if vim.v.exiting == vim.NIL then
+        task:on_exit(c)
+      end
+    end,
+    on_close = function(_)
+      log:debug("Closing terminal")
+    end,
+    auto_scroll = true,
+    close_on_exit = false,
+    hidden = false,
+  }):toggle()
+
+  chan_id = term.job_id
+  self.bufnr = term.bufnr
+
+  util.hack_around_termopen_autocmd(mode)
+
+  if chan_id == 0 then
+    error(string.format("Invalid arguments for task '%s'", task.name))
+  elseif chan_id == -1 then
+    error(string.format("Command '%s' not executable", vim.inspect(task.cmd)))
+  else
+    jobs.unregister(chan_id)
+    self.chan_id = chan_id
+  end
+end
+
+function ToggleTermStrategy:stop()
+  if self.chan_id then
+    vim.fn.jobstop(self.chan_id)
+    self.chan_id = nil
+  end
+end
+
+function ToggleTermStrategy:dispose()
+  self:stop()
+  util.soft_delete_buf(self.bufnr)
+end
+
+return ToggleTermStrategy


### PR DESCRIPTION
Implements the "ToggleTerm" strategy, which sources a terminal through ToggleTerm's `Terminal.new()` command. ToggleTerm will open up and run your task in it's own window, while preserving operation in the same way as the default terminal strategy (e.g. you can view output through the Overseer pane and status is correctly reported).