### PR TITLE
fix: mix tasks should generally prompt user for args

### DIFF
--- a/lua/overseer/form/init.lua
+++ b/lua/overseer/form/init.lua
@@ -83,7 +83,7 @@ function Builder.new(title, schema, params, callback)
   end)
   for k, v in pairs(schema) do
     if params[k] == nil then
-      params[k] = v.default
+      params[k] = vim.deepcopy(v.default)
     end
   end
 

--- a/lua/overseer/form/utils.lua
+++ b/lua/overseer/form/utils.lua
@@ -168,7 +168,7 @@ M.parse_value = function(schema, value)
   if schema.type == "opaque" then
     return false
   elseif value == "" then
-    return true, schema.default
+    return true, vim.deepcopy(schema.default)
   elseif schema.type == "list" then
     local values = vim.split(value, "%s*" .. schema.delimiter .. "%s*")
     local ret = {}

--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -6,15 +6,18 @@ local log = require("overseer.log")
 local tmpl = {
   priority = 60,
   params = {
-    args = { optional = true, type = "list", delimiter = " " },
+    subcmd = { optional = true },
+    args = { type = "list", delimiter = " ", default = {} },
   },
   builder = function(params)
     local cmd = { "mix" }
-    if params.args then
-      cmd = vim.list_extend(cmd, params.args)
+    local args = params.args or {}
+    if params.subcmd then
+      table.insert(args, 1, params.subcmd)
     end
     return {
       cmd = cmd,
+      args = args,
     }
   end,
 }
@@ -47,10 +50,11 @@ return {
             overseer.wrap_template(
               tmpl,
               { name = string.format("mix %s", task_name) },
-              { args = { task_name } }
+              { subcmd = task_name }
             )
           )
         end
+        table.insert(ret, overseer.wrap_template(tmpl, { name = "mix", priority = 65 }))
       end),
       on_exit = vim.schedule_wrap(function(j, output)
         cb(ret)


### PR DESCRIPTION
Per #71

This changes some of the formatting of the generated mix task parameters so that users will be prompted to input any args. This preserves the programmatic functionality of `run_template({name = "mix", params = {args = {'taskname', '--flag', '-o', 'option'}}})`