### PR TITLE
Added toggleterm to third_party.md and ref in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A task runner and job management plugin for Neovim
   - [Lualine](doc/third_party.md#lualine)
   - [Neotest](doc/third_party.md#neotest)
   - [DAP](doc/third_party.md#dap)
+  - [ToggleTerm](doc/third_party.md#toggleterm)
   - [Session managers](doc/third_party.md#session-managers)
 - [Recipes](#recipes)
   - [Restart last task](doc/recipes.md#restart-last-task)

--- a/doc/third_party.md
+++ b/doc/third_party.md
@@ -134,6 +134,8 @@ require('overseer').setup({
 })
 ```
 
+More documentation on this strategy can be found [here](strategies.md#toggletermopts).
+
 ## Session managers
 
 ### resession.nvim

--- a/doc/third_party.md
+++ b/doc/third_party.md
@@ -97,6 +97,43 @@ require('overseer').setup({
 
 If you have both overseer and [nvim-dap](https://github.com/mfussenegger/nvim-dap) installed, overseer will automatically run the `preLaunchTask` and `postDebugTask` when present in a debug configuration.
 
+## ToggleTerm
+
+If you use [toggleterm](https://github.com/akinsho/toggleterm.nvim), you can use the built-in "toggleterm" strategy to allow your tasks to be in a terminal buffer owned by toggleterm. You can use your existing toggleterm keybinds to pull up long-running tasks started with overseer. You can set it up with defaults using:
+
+```lua
+require('overseer').setup({
+  strategy = "toggleterm",
+})
+```
+
+You can also configure the behavior a bit more:
+
+```lua
+require('overseer').setup({
+  strategy = {
+    "toggleterm",
+    -- load your default shell before starting the task
+    use_shell = false,
+    -- overwrite the default toggleterm "direction" parameter
+    direction = nil,
+    -- overwrite the default toggleterm "dir" parameter
+    dir = nil,
+    -- overwrite the default toggleterm "highlights" parameter
+    highlights = nil,
+    -- overwrite the default toggleterm "auto_scroll" parameter
+    auto_scroll = nil,
+    -- have the toggleterm window close automatically after the task exits
+    close_on_exit = false,
+    -- open the toggleterm window when a task starts
+    open_on_start = true,
+    -- mirrors the toggleterm "hidden" parameter, and keeps the task from
+    -- being rendered in the toggleable window
+    hidden = false,
+  }
+})
+```
+
 ## Session managers
 
 ### resession.nvim


### PR DESCRIPTION
This adds documentation to the "third party" section of the README and docs, and refers to the existing `strategies.md` documentation.