### PR TITLE
OverseerOpen: focus also existing window

### DIFF
--- a/lua/overseer/window.lua
+++ b/lua/overseer/window.lua
@@ -70,10 +70,10 @@ M.open = function(opts)
     enter = true,
     direction = config.task_list.direction,
   })
-  if M.is_open() then
-    return
+  local winid = M.get_win_id()
+  if winid == nil then
+    winid = create_overseer_window(opts.direction, opts.winid)
   end
-  local winid = create_overseer_window(opts.direction, opts.winid)
   if opts.enter then
     vim.api.nvim_set_current_win(winid)
   end


### PR DESCRIPTION
OverseerOpen will only focus the window if it wasn't opened previously, which seems not to match the documentation, which mentions to use the ! if the user doesn't want to focus.

This change makes OverseerOpen always focus the window, whether it was previously open or not (unless the ! is given).