### PR TITLE
feat(npm): detect pnpm

### DIFF
--- a/lua/overseer/template/npm.lua
+++ b/lua/overseer/template/npm.lua
@@ -1,16 +1,18 @@
 local files = require("overseer.files")
 local overseer = require("overseer")
 
+local package_managers = { "npm", "pnpm", "yarn" }
+
 ---@type overseer.TemplateDefinition
 local tmpl = {
   priority = 60,
   params = {
     args = { optional = true, type = "list", delimiter = " " },
-    use_yarn = { optional = true, type = "boolean" },
     cwd = { optional = true },
+    bin = { optional = true, type = "string" },
   },
   builder = function(params)
-    local bin = params.use_yarn and "yarn" or "npm"
+    local bin = params.bin and params.bin or "npm"
     local cmd = { bin }
     if params.args then
       cmd = vim.list_extend(cmd, params.args)
@@ -30,14 +32,29 @@ local function get_package_file(opts)
   return filename
 end
 
+local function pick_package_manager(opts)
+  return files.exists(files.join(opts.dir, "yarn.lock")) and "yarn"
+    or files.exists(files.join(opts.dir, "pnpm-lock.yaml")) and "pnpm"
+    or "npm"
+end
+
+local function has_package_manager()
+  for _, bin in ipairs(package_managers) do
+    if vim.fn.executable(bin) == 1 then
+      return true
+    end
+  end
+  return false
+end
+
 return {
   cache_key = function(opts)
     return get_package_file(opts)
   end,
   condition = {
     callback = function(opts)
-      if vim.fn.executable("npm") == 0 and vim.fn.executable("yarn") == 0 then
-        return false, 'Commands "npm" and "yarn" not found'
+      if not has_package_manager() then
+        return false, "No valid package manager found."
       end
       if get_package_file(opts) == "" then
         return false, "No package.json file found"
@@ -47,8 +64,7 @@ return {
   },
   generator = function(opts, cb)
     local package = get_package_file(opts)
-    local use_yarn = files.exists(files.join(opts.dir, "yarn.lock"))
-    local bin = use_yarn and "yarn" or "npm"
+    local bin = pick_package_manager(opts)
     local data = files.load_json_file(package)
     local ret = {}
     if data.scripts then
@@ -58,7 +74,7 @@ return {
           overseer.wrap_template(
             tmpl,
             { name = string.format("%s %s", bin, k) },
-            { args = { "run", k }, use_yarn = use_yarn }
+            { args = { "run", k }, bin = bin }
           )
         )
       end
@@ -77,14 +93,14 @@ return {
               overseer.wrap_template(
                 tmpl,
                 { name = string.format("%s[%s] %s", bin, workspace, k) },
-                { args = { "run", k }, use_yarn = use_yarn, cwd = workspace_path }
+                { args = { "run", k }, bin = bin, cwd = workspace_path }
               )
             )
           end
         end
       end
     end
-    table.insert(ret, overseer.wrap_template(tmpl, { name = bin }, { use_yarn = use_yarn }))
+    table.insert(ret, overseer.wrap_template(tmpl, { name = bin }, { bin = bin }))
     cb(ret)
   end,
 }

--- a/lua/overseer/template/vscode/provider/npm.lua
+++ b/lua/overseer/template/vscode/provider/npm.lua
@@ -1,10 +1,19 @@
 local files = require("overseer.files")
 local M = {}
 
+local lockfiles = {
+  npm = "package-lock.json",
+  pnpm = "pnpm-lock.yaml",
+  yarn = "yarn.lock",
+}
+
 local function pick_package_manager()
-  return files.exists(files.join("yarn.lock")) and "yarn"
-      or files.exists(files.join("pnpm-lock.yaml")) and "pnpm"
-      or "npm"
+  for mgr, lockfile in pairs(lockfiles) do
+    if files.exists(lockfile) then
+      return mgr
+    end
+  end
+  return "npm"
 end
 
 M.get_task_opts = function(defn)

--- a/lua/overseer/template/vscode/provider/npm.lua
+++ b/lua/overseer/template/vscode/provider/npm.lua
@@ -1,10 +1,16 @@
 local files = require("overseer.files")
 local M = {}
 
+local function pick_package_manager()
+  return files.exists(files.join("yarn.lock")) and "yarn"
+      or files.exists(files.join("pnpm-lock.yaml")) and "pnpm"
+      or "npm"
+end
+
 M.get_task_opts = function(defn)
-  local use_yarn = files.exists("yarn.lock")
+  local bin = pick_package_manager()
   return {
-    cmd = { use_yarn and "yarn" or "npm", defn.script },
+    cmd = { bin, defn.script },
   }
 end
 


### PR DESCRIPTION
Detect `pnpm` via `pnpm-lock.yaml` similar to how we're doing for `yarn`. Changed the internal interface to expect an executable name instead of just a flip on `use_yarn`. That didn't look to me like an API that was exposed so it seemed safe to remove it.