### PR TITLE
Fixes #101 toggleterm integration with powershell

### DIFF
--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -5,6 +5,9 @@ local terminal = require("toggleterm.terminal")
 
 local ToggleTermStrategy = {}
 
+-- Name of powershell executables
+local powershell = {pwsh=1, powershell=1}
+
 ---Run tasks using the toggleterm plugin
 ---@param opts nil|table
 ---    use_shell nil|boolean load user shell before running task
@@ -67,7 +70,11 @@ function ToggleTermStrategy:start(task)
 
   local cmd = task.cmd
   if type(task.cmd) == "table" then
-    cmd = table.concat(vim.tbl_map(vim.fn.shellescape, task.cmd), " ")
+    if powershell[vim.o.shell] ~= nil then
+      cmd = table.concat(task.cmd, " ")
+    else
+      cmd = table.concat(vim.tbl_map(vim.fn.shellescape, task.cmd), " ")
+    end
   end
 
   local passed_cmd


### PR DESCRIPTION
This fixes #101 with the powershell toggleterm integration problem. The issue is that powershell doesn't like things wrapped in quotes, `"`. So the solution would be to not shell escape if the user has a `vim.o.shell` set to `pwsh` or `powershell`. I propose just adding a condition statement that checks the name of the `vim.o.shell` for a equivalent powershell name.

I scoped the table of powershell names to the entire toggle term file in case that data is useful for other functions.

A simple table lookup with the `vim.o.shell` gives either a 1 or a nil. If it is not nil then don't apply the shell escape. Otherwise apply the shell escape. I have tested this both on windows and linux and it works as expected. See the attached images for the command outputs with both control flows.

```lua
 local powershell = { pwsh=1, powershell=1 }

  local cmd = task.cmd
  if type(task.cmd) == "table" then
    if  powershell[vim.o.shell] ~= nil then
      cmd = table.concat(task.cmd, " ")
    else
      cmd = table.concat(vim.tbl_map(vim.fn.shellescape, task.cmd), " ")
    end
  end
```

## Windows Result

![ValidCommandWindows](https://user-images.githubusercontent.com/94603332/221377773-ed247cde-562f-4d85-b422-0116e1b7aee5.png)

## Linux Result

![ValidCommandLinux](https://user-images.githubusercontent.com/94603332/221377769-76b34116-e30c-46a4-aa34-a01d69b7fb3d.png)
