### PR TITLE
fix: error in SessionSavePre when g:session_save_commands is not defined

### DIFF
--- a/lua/overseer/init.lua
+++ b/lua/overseer/init.lua
@@ -41,7 +41,7 @@ local function do_setup()
     group = aug,
     callback = function()
       local task_list = require("overseer.task_list")
-      local cmds = vim.g.session_save_commands
+      local cmds = vim.g.session_save_commands or {}
       local tasks = vim.tbl_map(function(task)
         return task:serialize()
       end, task_list.list_tasks({ bundleable = true }))


### PR DESCRIPTION
With the recent support of SessionSavePre in possession (https://github.com/jedrzejboczar/possession.nvim/pull/26) overseer causes error when `vim.g.session_save_commands` is not defined. This PR just fixes the error, integration with possession won't work yet, but this is something that would have to be added in the possesion plugin.  