### PR TITLE
Add support for on_create in toggleterm strategy

### DIFF
--- a/doc/third_party.md
+++ b/doc/third_party.md
@@ -148,6 +148,9 @@ require('overseer').setup({
     -- mirrors the toggleterm "hidden" parameter, and keeps the task from
     -- being rendered in the toggleable window
     hidden = false,
+    -- command to run when the terminal is created. Combine with `use_shell`
+    -- to run a terminal command before starting the task
+    on_create = nil,
   }
 })
 ```

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -15,6 +15,7 @@ local ToggleTermStrategy = {}
 ---    close_on_exit nil|boolean close the terminal (if open) after task exits
 ---    open_on_start nil|boolean toggle open the terminal automatically when task starts
 ---    hidden nil|boolean cannot be toggled with normal ToggleTerm commands
+----   on_create nil|function function to execute on terminal creation
 ---@return overseer.Strategy
 function ToggleTermStrategy.new(opts)
   opts = vim.tbl_extend("keep", opts or {}, {
@@ -25,6 +26,7 @@ function ToggleTermStrategy.new(opts)
     close_on_exit = false,
     open_on_start = true,
     hidden = false,
+    on_create = nil,
   })
   if opts.dir then
     vim.notify_once(
@@ -86,6 +88,10 @@ function ToggleTermStrategy:start(task)
     close_on_exit = self.opts.close_on_exit,
     hidden = self.opts.hidden,
     on_create = function(t)
+      if self.opts.on_create then
+        self.opts.on_create(t)
+      end
+
       if self.opts.use_shell then
         t:send(cmd)
         t:send("exit $?")


### PR DESCRIPTION
Hi!

Lovely plugin! Thanks for creating it.

# Preface:

I use overseer to run tasks while programming Python. In particular, I have it run `python -m pip instal .` with some extra commands. I also use pyright with pyrightconfig.json, where I set the virtual environment to use. I have written some Lua to have neovim automatically use that virtual environment in `neotest` and `nvim-dap` and automatically source the `activate` script on creating `toggleterm` terminals. I use the vscode.json integration.

# What this pull-request does:

It enables support for the `on_create` callback from `toggleterm` so that one can run commands in the terminal before the task is started (if `use_shell=true`). I use this to source my virtual environment. But I suspect it can be useful for others as well. 

# Drawbacks

None that I can see. But there might be an obvious way of achiving the same result without patching the toggleterm runner.


