### PR TITLE
feat: add quit_on_exit option for toggleterm strategy

### DIFF
--- a/doc/third_party.md
+++ b/doc/third_party.md
@@ -196,8 +196,14 @@ require('overseer').setup({
     highlights = nil,
     -- overwrite the default toggleterm "auto_scroll" parameter
     auto_scroll = nil,
-    -- have the toggleterm window close automatically after the task exits
+    -- have the toggleterm window close and delete the terminal buffer
+    -- automatically after the task exits
     close_on_exit = false,
+    -- have the toggleterm window close without deleting the terminal buffer
+    -- automatically after the task exits
+    -- can be "never, "success", or "always". "success" will close the window
+    -- only if the exit code is 0.
+    quit_on_exit = "never",
     -- open the toggleterm window when a task starts
     open_on_start = true,
     -- mirrors the toggleterm "hidden" parameter, and keeps the task from

--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -12,8 +12,8 @@ local ToggleTermStrategy = {}
 ---    direction nil|"vertical"|"horizontal"|"tab"|"float"
 ---    highlights nil|table map to a highlight group name and a table of it's values
 ---    auto_scroll nil|boolean automatically scroll to the bottom on task output
----    close_on_exit "never"|"always"|"success" close the terminal (if open) after task exits
----    quit_on_exit nil|boolean close the terminal window (if open) after task exits
+---    close_on_exit nil|boolean close the terminal and delete terminal buffer (if open) after task exits
+---    quit_on_exit "never"|"always"|"success" close the terminal window (if open) after task exits
 ---    open_on_start nil|boolean toggle open the terminal automatically when task starts
 ---    hidden nil|boolean cannot be toggled with normal ToggleTerm commands
 ---    on_create nil|fun(term: table) function to execute on terminal creation


### PR DESCRIPTION
This option closes the terminal window (with `term:close()`) but does not get rid of the terminal buffer. This way you can still open in back up and view the output if necessary.

See #152 