### PR TITLE
fix: change the filename capture group to lazy/non-greedy match any char

### DIFF
--- a/lua/overseer/template/vscode/problem_matcher.lua
+++ b/lua/overseer/template/vscode/problem_matcher.lua
@@ -265,7 +265,7 @@ local default_matchers = {
     fileLocation = { "autoDetect", "${cwd}" },
     pattern = {
       regexp = "^(.*?) =(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
-      vim_regexp = "\\v^([^:]*):(\\d+):(\\d*):?\\s+%(fatal\\s+)?(warning|error):\\s+(.*)$",
+      vim_regexp = "\\v^(.{-}):(\\d+):(\\d*):?\\s+%(fatal\\s+)?(warning|error):\\s+(.*)$",
       file = 1,
       line = 2,
       column = 3,


### PR DESCRIPTION
The filename match group should be a lazy/non-greedy any-character pattern, as per original cpp-tools source, to more accurately match the filename at the start of the line.

This fixes diagnostics parsing on Windows where paths sometimes have a drive letter and colon at the start of the filename