### PR TITLE
fix: chunk lost when parsing output from stdout

### DIFF
--- a/lua/overseer/util.lua
+++ b/lua/overseer/util.lua
@@ -437,7 +437,7 @@ M.get_stdout_line_iter = function()
           pending = pending .. M.clean_job_line(chunk)
         end
       else
-        if data[1] ~= "" then
+        if not (data[1] == "" and i == 2) then
           table.insert(ret, pending)
         end
         pending = M.clean_job_line(chunk)


### PR DESCRIPTION
when receiving as `["", "abc", "def"]`, current implementation sets `pending` to be "abc" on the second iteration. However on the next iteration, `pending` is set to "def", and the "abc" chunk is lost.