### PR TITLE
fix: ignore case when searching for "justfile", support hidden files

### DIFF
--- a/lua/overseer/template/just.lua
+++ b/lua/overseer/template/just.lua
@@ -3,7 +3,11 @@ local log = require("overseer.log")
 ---@param opts overseer.SearchParams
 ---@return nil|string
 local function get_justfile(opts)
-  return vim.fs.find("justfile", { upward = true, type = "file", path = opts.dir })[1]
+  local is_justfile = function(name)
+    name = name:lower()
+    return name == "justfile" or name == ".justfile"
+  end
+  return vim.fs.find(is_justfile, { upward = true, type = "file", path = opts.dir })[1]
 end
 
 ---@type overseer.TemplateFileProvider


### PR DESCRIPTION
According to https://github.com/casey/just#quick-start the name can be uppercase or start with a dot:
> The search for a justfile is case insensitive, so any case, like Justfile, JUSTFILE, or JuStFiLe, will work. just will also look for files with the name .justfile, in case you'd like to hide a justfile.