### PR TITLE
fix: lazy-load dap when patching

### DIFF
--- a/lua/overseer/init.lua
+++ b/lua/overseer/init.lua
@@ -256,6 +256,9 @@ end
 ---@private
 ---@param enabled boolean
 M.patch_dap = function(enabled)
+  if not enabled and not package.loaded.dap then
+    return
+  end
   local ok, dap = pcall(require, "dap")
   if not ok then
     return


### PR DESCRIPTION
Fixes #212 

I removed the `enabled` parameter since this solution assumes that `enabled` is always true when invoking the function.