### PR TITLE
feat: change cwd to buffer dir on npm template for nested packages

### DIFF
--- a/lua/overseer/template/npm.lua
+++ b/lua/overseer/template/npm.lua
@@ -82,7 +82,7 @@ return {
           overseer.wrap_template(
             tmpl,
             { name = string.format("%s %s", bin, k) },
-            { args = { "run", k }, bin = bin }
+            { args = { "run", k }, bin = bin, cwd = vim.fs.dirname(package) }
           )
         )
       end


### PR DESCRIPTION
On monorepo, we may not want to execute npm scripts on current dir.

eg.

```
- repository root
    - package 1
        - package.json (with script like `build`)
        - src
            - some file.ts
    - package 2
        - package.json
        - ...
```

Currently when we run task of npm template on `some file.ts`, script (like `npm run build`) executed on root dir. This might be wrong.