### PR TITLE
doc: improve task_list.width description

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -93,11 +93,14 @@ require("overseer").setup({
     default_detail = 1,
     -- Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
     -- min_width and max_width can be a single value or a list of mixed integer/float types.
-    -- max_width = {100, 0.2} means "the lesser of 100 columns or 20% of total"
+    -- max_width = { 100, 0.2 } means "the lesser of 100 columns or 20% of total"
     max_width = { 100, 0.2 },
     -- min_width = {40, 0.1} means "the greater of 40 columns or 10% of total"
     min_width = { 40, 0.1 },
-    -- optionally define an integer/float for the exact width of the task list
+    -- Optionally define an integer/float for the exact width of the task list.
+    -- Note that min_width/max_width contraints are still applied after this, so when setting
+    -- width outside of the default min/max range you may need to do something like:
+    -- min_width = 0, max_width = 0.99, width = 20 (to set a default width of 20 columns)
     width = nil,
     max_height = { 20, 0.1 },
     min_height = 8,


### PR DESCRIPTION
It took me quite a while to find #16 and understand this, as it was not immediately obvious to me that min/max are still
applied if you define `width`. The original description may even be suggestive that `width` simply overrides min/max :D

This PR is an attempt to improve the docs there!

---
Awesome plugin btw - took me quite a while to figure out a usage pattern that works for me, but now I'm really enjoying it!