### PR TITLE
doc: Add name field to template_provider documentation

### DIFF
--- a/doc/guides.md
+++ b/doc/guides.md
@@ -114,8 +114,6 @@ Providers are created the same way templates are (with `overseer.register_templa
 
 ```lua
 {
-  -- Name of the provider
-  name = "Some provider",
   generator = function(search, cb)
     -- Pass a list of templates to the callback
     -- See the built-in providers for make or npm for an example

--- a/doc/guides.md
+++ b/doc/guides.md
@@ -114,6 +114,8 @@ Providers are created the same way templates are (with `overseer.register_templa
 
 ```lua
 {
+  -- Name of the provider
+  name = "Some provider",
   generator = function(search, cb)
     -- Pass a list of templates to the callback
     -- See the built-in providers for make or npm for an example

--- a/doc/overseer.txt
+++ b/doc/overseer.txt
@@ -524,6 +524,7 @@ wrap_template({base}, {override}, {default_params}): overseer.TemplateFileDefini
         }
       }
       local template_provider = {
+        name = "Some provider",
         generator = function(opts, cb)
           cb({
             overseer.wrap_template(tmpl, nil, { args = { 'all' } }),

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -594,6 +594,7 @@ local tmpl = {
   }
 }
 local template_provider = {
+  name = "Some provider",
   generator = function(opts, cb)
     cb({
       overseer.wrap_template(tmpl, nil, { args = { 'all' } }),

--- a/lua/overseer/init.lua
+++ b/lua/overseer/init.lua
@@ -470,6 +470,7 @@ M.run_action = lazy("action_util", "run_task_action")
 ---   }
 --- }
 --- local template_provider = {
+---   name = "Some provider",
 ---   generator = function(opts, cb)
 ---     cb({
 ---       overseer.wrap_template(tmpl, nil, { args = { 'all' } }),


### PR DESCRIPTION
`name` seems to be required for `template_provider`.

closes #236