### PR TITLE
mix: invoke in the folder of the mix.exs

### DIFF
--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -40,9 +40,8 @@ return {
     end,
   },
   generator = function(opts, cb)
-    -- mix will not return all the tasks unless you invoke it in the  mix.exs folder
-    local mix_folder =
-      vim.fs.dirname(vim.fs.find("mix.exs", { upward = true, type = "file", path = opts.dir })[1])
+    -- mix will not return all the tasks unless you invoke it in the mix.exs folder
+    local mix_folder = vim.fs.dirname(get_mix_file(opts))
     local ret = {}
     local jid = vim.fn.jobstart({
       "mix",

--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -41,7 +41,7 @@ return {
   },
   generator = function(opts, cb)
     -- mix will not return all the tasks unless you invoke it in the mix.exs folder
-    local mix_folder = vim.fs.dirname(get_mix_file(opts))
+    local mix_folder = vim.fs.dirname(assert(get_mix_file(opts)))
     local ret = {}
     local jid = vim.fn.jobstart({
       "mix",

--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -40,12 +40,15 @@ return {
     end,
   },
   generator = function(opts, cb)
+    -- mix will not return all the tasks unless you invoke it in the  mix.exs folder
+    local mix_folder =
+      vim.fs.dirname(vim.fs.find("mix.exs", { upward = true, type = "file", path = opts.dir })[1])
     local ret = {}
     local jid = vim.fn.jobstart({
       "mix",
       "help",
     }, {
-      cwd = opts.dir,
+      cwd = mix_folder,
       stdout_buffered = true,
       on_stdout = vim.schedule_wrap(function(j, output)
         for _, line in ipairs(output) do


### PR DESCRIPTION
so i didn't upgrade overseer in my config for a very long time... And I just now got the change where it's not anymore the current folder that's taken into account, but the current file's folder.

I needed that change to keep getting all the mix tasks that I would get previously...