### PR TITLE
Support for vscode's "hide" option

### DIFF
--- a/lua/overseer/commands.lua
+++ b/lua/overseer/commands.lua
@@ -309,7 +309,10 @@ M.run_template = function(opts, callback)
     template.get_by_name(opts.name, search_opts, handle_tmpl)
   else
     template.list(search_opts, function(templates)
-      templates = vim.tbl_filter(function(tmpl) return not tmpl.hide end, templates)
+      templates = vim.tbl_filter(function(tmpl)
+        return not tmpl.hide
+      end, templates)
+
       if #templates == 0 then
         log:error("Could not find any matching task templates for opts %s", opts)
       elseif #templates == 1 or opts.first then

--- a/lua/overseer/commands.lua
+++ b/lua/overseer/commands.lua
@@ -314,6 +314,7 @@ M.run_template = function(opts, callback)
       elseif #templates == 1 or opts.first then
         handle_tmpl(templates[1])
       else
+        templates = vim.tbl_filter(function(tmpl) return not tmpl.hide end, templates)
         vim.ui.select(templates, {
           prompt = "Task template:",
           kind = "overseer_template",

--- a/lua/overseer/commands.lua
+++ b/lua/overseer/commands.lua
@@ -309,12 +309,12 @@ M.run_template = function(opts, callback)
     template.get_by_name(opts.name, search_opts, handle_tmpl)
   else
     template.list(search_opts, function(templates)
+      templates = vim.tbl_filter(function(tmpl) return not tmpl.hide end, templates)
       if #templates == 0 then
         log:error("Could not find any matching task templates for opts %s", opts)
       elseif #templates == 1 or opts.first then
         handle_tmpl(templates[1])
       else
-        templates = vim.tbl_filter(function(tmpl) return not tmpl.hide end, templates)
         vim.ui.select(templates, {
           prompt = "Task template:",
           kind = "overseer_template",

--- a/lua/overseer/template/init.lua
+++ b/lua/overseer/template/init.lua
@@ -25,6 +25,7 @@ local M = {}
 ---@field priority? number
 ---@field condition? overseer.SearchCondition
 ---@field builder fun(params: table): overseer.TaskDefinition
+---@field hide? boolean Hide from the template list
 
 ---@class overseer.TemplateDefinition : overseer.TemplateFileDefinition
 ---@field name string

--- a/lua/overseer/template/vscode/init.lua
+++ b/lua/overseer/template/vscode/init.lua
@@ -246,6 +246,9 @@ local function convert_vscode_task(defn, precalculated_vars)
     )
     return nil
   end
+  if defn.hide then
+    tmpl.hide = true
+  end
 
   -- NOTE: we ignore defn.presentation
   -- NOTE: we intentionally do nothing with defn.runOptions.


### PR DESCRIPTION
I added a field to the TemplateDefinition called `hide`, that is used in the `run_template` function to filter templates and only show to the user the not hidden one.

I tried reading the code base and it seemed the most concise yet aligned solution I could come up with.

Please let me know if there are any chore addition needed, it didn't seem the documentation should be updated since it is an "internal" change nothing new should be exposed to the user.

I hope you'd like it and maybe it can close issue #269