### PR TITLE
fix: add missing space after `running` glyph

### DIFF
--- a/lua/lualine/components/overseer.lua
+++ b/lua/lualine/components/overseer.lua
@@ -51,7 +51,7 @@ local default_icons = {
   [STATUS.FAILURE] = "󰅚 ",
   [STATUS.CANCELED] = " ",
   [STATUS.SUCCESS] = "󰄴 ",
-  [STATUS.RUNNING] = "󰑮",
+  [STATUS.RUNNING] = "󰑮 ",
 }
 local default_no_icons = {
   [STATUS.FAILURE] = "F:",


### PR DESCRIPTION
The other status icons/glyphs have an additional space defined, without this space the running task count number gets squeezed with the icon (at least with my terminal set-up).

Note: This is probably a `grapheme cluster` thing (https://mitchellh.com/writing/grapheme-clusters-in-terminals)

--

BTW: thanks for creating and sharing `overseer`, it is IMHO a beautiful piece of engineering which inspires me a lot 🙏🏻