### PR TITLE
Tiny update in README.md regarding lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ overseer supports all the usual plugin managers
   <summary>lazy.nvim</summary>
 
 ```lua
-{
+return {
   'stevearc/overseer.nvim',
   opts = {},
 }


### PR DESCRIPTION
fix: lazy.nvim overseer plugin syntax fix (for use as standalone plugin in ~/.config/nvim/lua/plugins/overseer.lua)

thanks for your amazing documentation ❤️ 