### PR TITLE
feat: add ambivalent groups (#299)

### DIFF
--- a/lua/overseer/config.lua
+++ b/lua/overseer/config.lua
@@ -11,6 +11,8 @@ local default_config = {
   task_list = {
     -- Default detail level for tasks. Can be 1-3.
     default_detail = 1,
+    -- Default position to display the group. Can be "top" or "bottom".
+    group_position = "top",
     -- Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
     -- min_width and max_width can be a single value or a list of mixed integer/float types.
     -- max_width = {100, 0.2} means "the lesser of 100 columns or 20% of total"

--- a/lua/overseer/strategy/orchestrator.lua
+++ b/lua/overseer/strategy/orchestrator.lua
@@ -1,6 +1,7 @@
 -- This is a run strategy for "meta" tasks. This task itself will not perform
 -- any jobs, but will instead wrap and manage a collection of other tasks.
 local Task = require("overseer.task")
+local config = require("overseer.config")
 local constants = require("overseer.constants")
 local log = require("overseer.log")
 local task_list = require("overseer.task_list")
@@ -242,8 +243,10 @@ function OrchestratorStrategy:start(task)
               if section_complete(1) then
                 self:start_next()
               end
-              -- Ensure the orchestrator task is sorted more recent than all children
-              task_list.touch_task(task)
+              if config.task_list.group_position == "top" then
+                -- Ensure the orchestrator task is sorted more recent than all children
+                task_list.touch_task(task)
+              end
             end)
           )
         end)

--- a/lua/overseer/task_list/init.lua
+++ b/lua/overseer/task_list/init.lua
@@ -1,3 +1,4 @@
+local config = require("overseer.config")
 local util = require("overseer.util")
 local M = {}
 
@@ -48,7 +49,9 @@ M.update = function(task)
   if not lookup[task.id] then
     lookup[task.id] = task
     table.insert(tasks, task)
-    group_parents_and_children()
+    if config.task_list.group_position == "top" then
+      group_parents_and_children()
+    end
   end
   rerender()
 end
@@ -62,7 +65,9 @@ M.touch_task = function(task)
   end)
   table.remove(tasks, idx)
   table.insert(tasks, task)
-  group_parents_and_children()
+  if config.task_list.group_position == "top" then
+    group_parents_and_children()
+  end
   rerender()
 end
 

--- a/lua/overseer/task_list/sidebar.lua
+++ b/lua/overseer/task_list/sidebar.lua
@@ -329,11 +329,7 @@ function Sidebar:render(tasks)
     end
     table.insert(self.task_lines, { #lines, task })
     if i > 1 then
-      if tasks[i - 1].parent_id then
-        table.insert(lines, subtask_prefix .. vim.fn.strcharpart(config.task_list.separator, 2))
-      else
-        table.insert(lines, config.task_list.separator)
-      end
+      table.insert(lines, subtask_prefix .. vim.fn.strcharpart(config.task_list.separator, 2))
       table.insert(highlights, { "OverseerTaskBorder", #lines, 0, -1 })
     end
   end


### PR DESCRIPTION
This is an improvement of #299. It give groups an appearance that look good in both directions

* `group_position=top`
![screenshot_2024-06-01_01-19-14_216892574](https://github.com/stevearc/overseer.nvim/assets/3357792/142f0899-329b-4b06-be2e-6720c5f9c7c9)

* `group_position=bottom`
![screenshot_2024-06-01_01-18-51_514207579](https://github.com/stevearc/overseer.nvim/assets/3357792/5e5c041c-203b-4c71-a7ac-ffc00a824468)

This is just a visual change.