### PR TITLE
feat: add ambivalent appearance to groups

### DIFF
--- a/lua/overseer/task_list/sidebar.lua
+++ b/lua/overseer/task_list/sidebar.lua
@@ -329,11 +329,7 @@ function Sidebar:render(tasks)
     end
     table.insert(self.task_lines, { #lines, task })
     if i > 1 then
-      if tasks[i - 1].parent_id then
-        table.insert(lines, subtask_prefix .. vim.fn.strcharpart(config.task_list.separator, 2))
-      else
-        table.insert(lines, config.task_list.separator)
-      end
+      table.insert(lines, subtask_prefix .. vim.fn.strcharpart(config.task_list.separator, 2))
       table.insert(highlights, { "OverseerTaskBorder", #lines, 0, -1 })
     end
   end


### PR DESCRIPTION
This is an improvement of #299. It give groups an appearance that look good in both directions

* `group_position=top`
![screenshot_2024-06-01_01-19-14_216892574](https://github.com/stevearc/overseer.nvim/assets/3357792/142f0899-329b-4b06-be2e-6720c5f9c7c9)

* `group_position=bottom`
![screenshot_2024-06-01_01-18-51_514207579](https://github.com/stevearc/overseer.nvim/assets/3357792/5e5c041c-203b-4c71-a7ac-ffc00a824468)

This is just a visual change.