### PR TITLE
feat: new open_output component

### DIFF
--- a/doc/components.md
+++ b/doc/components.md
@@ -15,6 +15,7 @@
 - [on_result_diagnostics](#on_result_diagnostics)
 - [on_result_diagnostics_quickfix](#on_result_diagnostics_quickfix)
 - [on_result_notify](#on_result_notify)
+- [open_output](#open_output)
 - [restart_on_save](#restart_on_save)
 - [run_after](#run_after)
 - [timeout](#timeout)
@@ -189,6 +190,22 @@ Normally you will want to use on_complete_notify. If you have a long-running wat
 | system                        | `enum`    | `"never"` | When to send a system notification (`"always"\|"never"\|"unfocused"`)         |
 
 - **on_change:** This only works when infer_status_from_diagnostics = true
+
+## open_output
+
+[open_output.lua](../lua/overseer/component/open_output.lua)
+
+Open task output
+
+| Param       | Type      | Default    | Desc                                                                                    |
+| ----------- | --------- | ---------- | --------------------------------------------------------------------------------------- |
+| direction   | `enum`    | `"dock"`   | Where to open the task output (`"dock"\|"float"\|"tab"\|"vertical"\|"horizontal"`)      |
+| focus       | `boolean` | `false`    | Focus the output window when it is opened                                               |
+| on_complete | `enum`    | `"always"` | Open the output when the task completes (`"always"\|"never"\|"success"\|"failure"`)     |
+| on_result   | `enum`    | `"never"`  | Open the output when the task produces a result (`"always"\|"never"\|"if_diagnostics"`) |
+| on_start    | `boolean` | `false`    | Open the output when the task starts                                                    |
+
+- **direction:** The 'dock' option will open the output docked to the bottom next to the task list.
 
 ## restart_on_save
 

--- a/doc/overseer.txt
+++ b/doc/overseer.txt
@@ -341,10 +341,11 @@ toggle({opts})                                                   *overseer.toggl
 
     Parameters:
       {opts} `nil|overseer.WindowOpts`
-          {enter}     `nil|boolean`
-          {direction} `nil|"left"|"right"|"bottom"`
-          {winid}     `nil|integer` Use this existing window instead of opening
-                      a new window
+          {enter}         `nil|boolean`
+          {direction}     `nil|"left"|"right"|"bottom"`
+          {winid}         `nil|integer` Use this existing window instead of
+                          opening a new window
+          {focus_task_id} `nil|integer` After opening, focus this task
 
 open({opts})                                                       *overseer.open*
     Open the task list
@@ -771,6 +772,25 @@ on_result_notify                                                *on_result_notif
                   infer_status_from_diagnostics = true
       {system}    `enum` When to send a system notification (default `"never"`)
                   (choices: `"always"|"never"|"unfocused"`)
+
+open_output                                                          *open_output*
+    Open task output
+
+    Parameters:
+      {direction}   `enum` Where to open the task output (default `"dock"`) The
+                    'dock' option will open the output docked to the bottom next
+                    to the task list. (choices:
+                    `"dock"|"float"|"tab"|"vertical"|"horizontal"`)
+      {focus}       `boolean` Focus the output window when it is opened (default
+                    `false`)
+      {on_complete} `enum` Open the output when the task completes (default
+                    `"always"`) (choices:
+                    `"always"|"never"|"success"|"failure"`)
+      {on_result}   `enum` Open the output when the task produces a result
+                    (default `"never"`) (choices:
+                    `"always"|"never"|"if_diagnostics"`)
+      {on_start}    `boolean` Open the output when the task starts (default
+                    `false`)
 
 restart_on_save                                                  *restart_on_save*
     Restart on any buffer :write

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -41,6 +41,7 @@
   - [on_result_diagnostics](components.md#on_result_diagnostics)
   - [on_result_diagnostics_quickfix](components.md#on_result_diagnostics_quickfix)
   - [on_result_notify](components.md#on_result_notify)
+  - [open_output](components.md#open_output)
   - [restart_on_save](components.md#restart_on_save)
   - [run_after](components.md#run_after)
   - [timeout](components.md#timeout)
@@ -385,6 +386,7 @@ Open or close the task list
 |       | enter                      | `nil\|boolean`                   |                                                          |
 |       | direction                  | `nil\|"left"\|"right"\|"bottom"` |                                                          |
 |       | winid                      | `nil\|integer`                   | Use this existing window instead of opening a new window |
+|       | focus_task_id              | `nil\|integer`                   | After opening, focus this task                           |
 
 ### open(opts)
 
@@ -721,6 +723,7 @@ Open a tab with windows laid out for debugging a parser
 - [on_result_diagnostics](components.md#on_result_diagnostics)
 - [on_result_diagnostics_quickfix](components.md#on_result_diagnostics_quickfix)
 - [on_result_notify](components.md#on_result_notify)
+- [open_output](components.md#open_output)
 - [restart_on_save](components.md#restart_on_save)
 - [run_after](components.md#run_after)
 - [timeout](components.md#timeout)

--- a/lua/overseer/component/init.lua
+++ b/lua/overseer/component/init.lua
@@ -62,6 +62,7 @@ local builtin_components = {
   "on_result_diagnostics",
   "on_result_diagnostics_quickfix",
   "on_result_notify",
+  "open_output",
   "restart_on_save",
   "run_after",
   "timeout",

--- a/lua/overseer/component/open_output.lua
+++ b/lua/overseer/component/open_output.lua
@@ -1,0 +1,97 @@
+local constants = require("overseer.constants")
+local STATUS = constants.STATUS
+
+---@param task overseer.Task
+---@param direction "dock"|"float"|"tab"|"vertical"|"horizontal"
+---@param focus boolean
+local function open_output(task, direction, focus)
+  if direction == "dock" then
+    local window = require("overseer.window")
+    window.open({
+      direction = "bottom",
+      enter = focus,
+      focus_task_id = task.id,
+    })
+  else
+    local winid = vim.api.nvim_get_current_win()
+    ---@cast direction "float"|"tab"|"vertical"|"horizontal"
+    task:open_output(direction)
+    if not focus then
+      vim.api.nvim_set_current_win(winid)
+    end
+  end
+end
+
+---@type overseer.ComponentFileDefinition
+local comp = {
+  desc = "Open task output",
+  params = {
+    on_start = {
+      desc = "Open the output when the task starts",
+      type = "boolean",
+      default = false,
+    },
+    on_complete = {
+      desc = "Open the output when the task completes",
+      type = "enum",
+      choices = { "always", "never", "success", "failure" },
+      default = "always",
+    },
+    on_result = {
+      desc = "Open the output when the task produces a result",
+      type = "enum",
+      choices = { "always", "never", "if_diagnostics" },
+      default = "never",
+    },
+    direction = {
+      desc = "Where to open the task output",
+      type = "enum",
+      choices = { "dock", "float", "tab", "vertical", "horizontal" },
+      default = "dock",
+      long_desc = "The 'dock' option will open the output docked to the bottom next to the task list.",
+    },
+    focus = {
+      desc = "Focus the output window when it is opened",
+      type = "boolean",
+      default = false,
+    },
+  },
+  constructor = function(params)
+    local methods = {}
+
+    if params.on_start then
+      methods.on_start = function(self, task)
+        open_output(task, params.direction, params.focus)
+      end
+    end
+
+    if params.on_result ~= "never" then
+      methods.on_result = function(self, task, result)
+        if
+          params.on_result == "always"
+          or (
+            params.on_result == "if_diagnostics" and not vim.tbl_isempty(result.diagnostics or {})
+          )
+        then
+          open_output(task, params.direction, params.focus)
+        end
+      end
+    end
+
+    if params.on_complete ~= "never" then
+      methods.on_complete = function(self, task, status, result)
+        if
+          params.on_complete == "always"
+          or (params.on_complete == "success" and status == STATUS.SUCCESS)
+          or (params.on_complete == "failure" and status == STATUS.FAILURE)
+        then
+          open_output(task, params.direction, params.focus)
+        end
+      end
+    end
+
+    return methods
+  end,
+}
+
+return comp

--- a/lua/overseer/strategy/init.lua
+++ b/lua/overseer/strategy/init.lua
@@ -32,7 +32,7 @@ function NilStrategy:stop() end
 
 function NilStrategy:dispose() end
 
----@param name_or_config string|table
+---@param name_or_config? string|table
 ---@return overseer.Strategy
 M.load = function(name_or_config)
   if not name_or_config then

--- a/lua/overseer/strategy/jobstart.lua
+++ b/lua/overseer/strategy/jobstart.lua
@@ -47,7 +47,6 @@ end
 function JobstartStrategy:start(task)
   if not self.bufnr then
     self.bufnr = vim.api.nvim_create_buf(false, true)
-    vim.b[self.bufnr].overseer_task = task.id
     if self.opts.use_terminal then
       local mode = vim.api.nvim_get_mode().mode
       local term_id

--- a/lua/overseer/strategy/terminal.lua
+++ b/lua/overseer/strategy/terminal.lua
@@ -32,7 +32,6 @@ end
 ---@param task overseer.Task
 function TerminalStrategy:start(task)
   self.bufnr = vim.api.nvim_create_buf(false, true)
-  vim.b[self.bufnr].overseer_task = task.id
   local chan_id
   local mode = vim.api.nvim_get_mode().mode
   local stdout_iter = util.get_stdout_line_iter()

--- a/lua/overseer/task.lua
+++ b/lua/overseer/task.lua
@@ -138,7 +138,7 @@ function Task.new(opts)
   next_id = next_id + 1
   task:dispatch("on_init")
   local bufnr = task:get_bufnr()
-  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+  if bufnr then
     vim.b[bufnr].overseer_task = task.id
   end
   return task
@@ -603,7 +603,7 @@ function Task:dispose(force)
     log:debug("Not disposing task %s: has %d references", self.name, self._references)
     return false
   end
-  local bufnr = self.strategy:get_bufnr()
+  local bufnr = self:get_bufnr()
   local bufnr_visible = util.is_bufnr_visible(bufnr)
   if not force then
     -- Can't dispose if the strategy bufnr is open

--- a/lua/overseer/task.lua
+++ b/lua/overseer/task.lua
@@ -1,4 +1,5 @@
 local component = require("overseer.component")
+local config = require("overseer.config")
 local constants = require("overseer.constants")
 local form_utils = require("overseer.form.utils")
 local layout = require("overseer.layout")
@@ -19,13 +20,13 @@ local STATUS = constants.STATUS
 ---@field cmd string|string[]
 ---@field cwd string
 ---@field env? table<string, string>
----@field strategy_defn? string|table
----@field strategy? overseer.Strategy
+---@field strategy_defn string|table
+---@field strategy overseer.Strategy
 ---@field name string
----@field private bufnr? number
 ---@field exit_code? number
 ---@field components overseer.Component[]
 ---@field parent_id? integer ID of parent task. Used only to visually group tasks in the task list
+---@field private prev_bufnr? integer
 ---@field private _subscribers table<string, function[]>
 local Task = {}
 
@@ -99,6 +100,11 @@ function Task.new_uninitialized(opts)
     end
   end
   name = name:gsub("\n", " ")
+
+  if not opts.strategy then
+    opts.strategy = config.strategy
+  end
+
   -- Build the instance data for the task
   local data = {
     result = nil,
@@ -114,7 +120,6 @@ function Task.new_uninitialized(opts)
     strategy_defn = opts.strategy,
     strategy = strategy.load(opts.strategy),
     name = name,
-    bufnr = nil,
     exit_code = nil,
     prev_bufnr = nil,
     components = {},
@@ -132,6 +137,10 @@ function Task.new(opts)
   task.id = next_id
   next_id = next_id + 1
   task:dispatch("on_init")
+  local bufnr = task:get_bufnr()
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+    vim.b[bufnr].overseer_task = task.id
+  end
   return task
 end
 
@@ -695,6 +704,7 @@ function Task:start()
   local bufnr = self.strategy:get_bufnr()
   if bufnr then
     vim.bo[bufnr].buflisted = false
+    vim.b[bufnr].overseer_task = self.id
   end
 
   util.replace_buffer_in_wins(self.prev_bufnr, bufnr)

--- a/lua/overseer/task_list/sidebar.lua
+++ b/lua/overseer/task_list/sidebar.lua
@@ -134,6 +134,24 @@ function Sidebar:_get_task_from_line(lnum)
   end
 end
 
+---@param task_id integer
+function Sidebar:focus_task_id(task_id)
+  local winid = self:_get_winid()
+  if not winid then
+    return
+  end
+  local lnum = 1
+  for _, v in ipairs(self.task_lines) do
+    local lines, task = v[1], v[2]
+    if task.id == task_id then
+      vim.api.nvim_win_set_cursor(winid, { lnum, 0 })
+      self:_set_task_focused(task_id)
+      return
+    end
+    lnum = lnum + lines
+  end
+end
+
 ---@param bufnr integer
 ---@param winlayout nil|any
 ---@return nil|"left"|"right"|"bottom"

--- a/lua/overseer/task_list/sidebar.lua
+++ b/lua/overseer/task_list/sidebar.lua
@@ -1,3 +1,4 @@
+local TaskView = require("overseer.task_view")
 local action_util = require("overseer.action_util")
 local binding_util = require("overseer.binding_util")
 local bindings = require("overseer.task_list.bindings")
@@ -8,6 +9,13 @@ local util = require("overseer.util")
 
 local M = {}
 
+---@class overseer.Sidebar
+---@field bufnr integer
+---@field default_detail integer
+---@field private task_lines {[1]: integer, [2]: overseer.Task}[]
+---@field private task_detail table<integer, integer>
+---@field private preview? overseer.TaskView
+---@field private focused_task_id? integer
 local Sidebar = {}
 
 local ref
@@ -46,6 +54,7 @@ function Sidebar.new()
     default_detail = config.task_list.default_detail,
     task_detail = {},
     task_lines = {},
+    preview = nil,
   }, { __index = Sidebar })
 
   vim.api.nvim_create_autocmd({ "BufHidden", "WinLeave" }, {
@@ -56,8 +65,17 @@ function Sidebar.new()
   vim.api.nvim_create_autocmd("CursorMoved", {
     desc = "Update preview window when cursor moves",
     buffer = bufnr,
+    nested = true,
     callback = function()
-      tl:update_preview()
+      local task = tl:_get_task_from_line()
+      tl:_set_task_focused(task and task.id)
+    end,
+  })
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "OverseerListUpdate",
+    desc = "Update overseer task list when tasks change",
+    callback = function()
+      tl:render(task_list.list_tasks())
     end,
   })
 
@@ -82,6 +100,21 @@ function Sidebar:_get_winid()
       return winid
     end
   end
+end
+
+---@param task_id? integer
+function Sidebar:_set_task_focused(task_id)
+  if task_id == self.focused_task_id then
+    return
+  end
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "OverseerListTaskHover",
+    modeline = false,
+    data = {
+      task_id = task_id,
+    },
+  })
+  self.focused_task_id = task_id
 end
 
 ---@return nil|overseer.Task
@@ -130,14 +163,8 @@ local function detect_direction(bufnr, winlayout)
 end
 
 function Sidebar:toggle_preview()
-  local pwin = util.get_preview_window()
-  if pwin then
-    vim.cmd.pclose()
-    return
-  end
-  local task = self:_get_task_from_line()
-  local task_bufnr = task and task:get_bufnr()
-  if not task or not task_bufnr or not vim.api.nvim_buf_is_valid(task_bufnr) then
+  if self.preview and not self.preview:is_disposed() then
+    self.preview:dispose()
     return
   end
 
@@ -153,7 +180,7 @@ function Sidebar:toggle_preview()
     height = layout.get_editor_height() - vim.api.nvim_win_get_height(0) - 1 - 2 * padding
   end
   local col = (direction == "left" and (win_width + padding) or padding)
-  local winid = vim.api.nvim_open_win(task_bufnr, false, {
+  local winid = vim.api.nvim_open_win(0, false, {
     relative = "editor",
     border = config.task_win.border,
     row = 1,
@@ -163,13 +190,23 @@ function Sidebar:toggle_preview()
     style = "minimal",
     noautocmd = true,
   })
-  vim.api.nvim_set_option_value("previewwindow", true, { scope = "local", win = winid })
   for k, v in pairs(config.task_win.win_opts) do
     vim.api.nvim_set_option_value(k, v, { scope = "local", win = winid })
   end
-  if winid then
-    util.scroll_to_end(winid)
-  end
+  self.preview = TaskView.new(winid, {
+    close_on_list_close = true,
+    select = function(_, tasks, task_under_cursor)
+      return task_under_cursor or tasks[1]
+    end,
+  })
+  vim.api.nvim_create_autocmd("WinLeave", {
+    desc = "Close task preview when leaving overseer list",
+    once = true,
+    callback = function()
+      self.preview:dispose()
+    end,
+  })
+  util.scroll_to_end(winid)
 end
 
 function Sidebar:change_task_detail(delta)
@@ -215,36 +252,6 @@ function Sidebar:_get_preview_wins()
     table.insert(ret, winid)
   end
   return ret
-end
-
-function Sidebar:update_preview()
-  local winids = self:_get_preview_wins()
-  if vim.tbl_isempty(winids) then
-    return
-  end
-  local task = self:_get_task_from_line()
-  local display_buf = task and task:get_bufnr()
-  if not display_buf or not vim.api.nvim_buf_is_valid(display_buf) then
-    display_buf = vim.api.nvim_create_buf(false, true)
-    vim.bo[display_buf].bufhidden = "wipe"
-    vim.b[display_buf].overseer_task = -1
-    vim.api.nvim_buf_set_lines(display_buf, 0, -1, true, { "--no task buffer--" })
-    if task then
-      -- The task hasn't started yet and doesn't have a buffer.
-      -- Add a callback to retry once the task does start
-      task:subscribe("on_start", function()
-        self:update_preview()
-        return false
-      end)
-    end
-  end
-
-  for _, winid in ipairs(winids) do
-    if vim.api.nvim_win_get_buf(winid) ~= display_buf then
-      vim.api.nvim_win_set_buf(winid, display_buf)
-      util.scroll_to_end(winid)
-    end
-  end
 end
 
 function Sidebar:jump(direction)
@@ -351,15 +358,12 @@ function Sidebar:render(tasks)
   util.add_highlights(self.bufnr, ns, highlights)
 
   if prev_first_task_id ~= new_first_task_id then
-    local output_wins = self:_get_output_wins()
-    local has_output_wins = not vim.tbl_isempty(output_wins)
     local in_sidebar = vim.api.nvim_get_current_buf() == self.bufnr
-    local in_output_win = vim.tbl_contains(output_wins, vim.api.nvim_get_current_win())
-    if has_output_wins and not in_sidebar and not in_output_win then
+    local in_output_win = vim.b.overseer_task ~= nil
+    if not in_sidebar and not in_output_win then
       for _, winid in ipairs(util.buf_list_wins(self.bufnr)) do
         vim.api.nvim_win_set_cursor(winid, { 1, 0 })
       end
-      self:update_preview()
     end
   end
   if sidebar_winid and view then

--- a/lua/overseer/task_view.lua
+++ b/lua/overseer/task_view.lua
@@ -1,0 +1,176 @@
+local task_list = require("overseer.task_list")
+
+local min_win_opts = {
+  number = false,
+  relativenumber = false,
+  cursorline = false,
+  cursorcolumn = false,
+  foldcolumn = "0",
+  signcolumn = "no",
+  spell = false,
+  list = false,
+}
+---@param winid integer
+local function set_minimal_win_opts(winid)
+  for k, v in pairs(min_win_opts) do
+    vim.api.nvim_set_option_value(k, v, { scope = "local", win = winid })
+  end
+end
+
+---@class (exact) overseer.TaskViewOpts
+---@field select? fun(self: overseer.TaskView, tasks: overseer.Task[], task_under_cursor: overseer.Task?): overseer.Task?
+---@field close_on_list_close? boolean Close the window when the task list is closed
+
+---@class overseer.TaskView
+---@field winid integer
+---@field private select fun(self: overseer.TaskView, tasks: overseer.Task[], task_under_cursor: overseer.Task?): overseer.Task?
+---@field private autocmd_ids integer[]
+local TaskView = {}
+
+---@param winid integer
+---@param opts? overseer.TaskViewOpts
+---@return overseer.TaskView
+function TaskView.new(winid, opts)
+  opts = opts or {}
+  if winid == 0 then
+    winid = vim.api.nvim_get_current_win()
+  end
+  set_minimal_win_opts(winid)
+  local self = setmetatable({
+    winid = winid,
+    select = opts.select or function(self, tasks)
+      return tasks[1]
+    end,
+    autocmd_ids = {},
+  }, { __index = TaskView })
+
+  -- Create one single autocmd that tracks the task_id under the cursor
+  if not TaskView.cursor_track_autocmd_id then
+    TaskView.cursor_track_autocmd_id = vim.api.nvim_create_autocmd("User", {
+      desc = "Update task view when cursor moves in task list",
+      pattern = "OverseerListTaskHover",
+      callback = function(args)
+        local task_id = args.data.task_id
+        TaskView.task_under_cursor = task_id and task_list.get(task_id)
+      end,
+    })
+  end
+  -- Create one single autocmd that tracks task list focus
+  if not TaskView.focus_autocmd_id then
+    TaskView.focus_autocmd_id = vim.api.nvim_create_autocmd("WinEnter", {
+      desc = "Track focus on Overseer task list",
+      nested = true,
+      callback = function()
+        vim.api.nvim_exec_autocmds(
+          "User",
+          { pattern = "OverseerListFocusChanged", modeline = false }
+        )
+      end,
+    })
+  end
+
+  table.insert(
+    self.autocmd_ids,
+    vim.api.nvim_create_autocmd("User", {
+      desc = "Update task view when task list changes",
+      pattern = "OverseerListUpdate",
+      callback = function()
+        self:update()
+      end,
+    })
+  )
+  if opts.close_on_list_close then
+    table.insert(
+      self.autocmd_ids,
+      vim.api.nvim_create_autocmd("User", {
+        desc = "Close task view when task list is closed",
+        pattern = "OverseerListClose",
+        callback = function()
+          self:dispose()
+        end,
+      })
+    )
+  end
+  table.insert(
+    self.autocmd_ids,
+    vim.api.nvim_create_autocmd("User", {
+      desc = "Update task view when cursor moves in task list",
+      pattern = "OverseerListTaskHover",
+      callback = function()
+        self:update()
+      end,
+    })
+  )
+  table.insert(
+    self.autocmd_ids,
+    vim.api.nvim_create_autocmd("User", {
+      desc = "Update task view when focusing the task list",
+      pattern = "OverseerListFocusChanged",
+      callback = function()
+        self:update()
+      end,
+    })
+  )
+  self:update()
+  return self
+end
+
+---@return boolean
+function TaskView:is_disposed()
+  return not vim.api.nvim_win_is_valid(self.winid)
+end
+
+local empty_bufnr = nil
+---@return integer
+local function get_empty_bufnr()
+  if not empty_bufnr or not vim.api.nvim_buf_is_valid(empty_bufnr) then
+    empty_bufnr = vim.api.nvim_create_buf(false, true)
+    vim.b[empty_bufnr].overseer_task = -1
+    vim.api.nvim_buf_set_lines(empty_bufnr, 0, -1, true, { "--no task buffer--" })
+    vim.bo[empty_bufnr].bufhidden = "wipe"
+  end
+  return empty_bufnr
+end
+
+function TaskView:update()
+  if self:is_disposed() then
+    return
+  end
+
+  if TaskView.task_under_cursor and TaskView.task_under_cursor:is_disposed() then
+    TaskView.task_under_cursor = nil
+  end
+
+  local tasks = task_list.list_tasks({ recent_first = true })
+  local task = self.select(self, tasks, TaskView.task_under_cursor)
+  -- select() function can call dispose()
+  if self:is_disposed() then
+    return
+  end
+
+  local bufnr = task and task:get_bufnr()
+  if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+    bufnr = get_empty_bufnr()
+  end
+
+  if bufnr ~= vim.api.nvim_win_get_buf(self.winid) then
+    local has_stickybuf, stickybuf = pcall(require, "stickybuf")
+    if has_stickybuf then
+      stickybuf.unpin(self.winid)
+    end
+    vim.api.nvim_win_set_buf(self.winid, bufnr)
+    set_minimal_win_opts(self.winid)
+  end
+end
+
+function TaskView:dispose()
+  if self.winid and vim.api.nvim_win_is_valid(self.winid) then
+    vim.api.nvim_win_close(self.winid, true)
+  end
+  for _, id in ipairs(self.autocmd_ids) do
+    vim.api.nvim_del_autocmd(id)
+  end
+  self.autocmd_ids = {}
+end
+
+return TaskView

--- a/lua/overseer/types.lua
+++ b/lua/overseer/types.lua
@@ -1,4 +1,4 @@
----@class overseer.Config
+---@class (exact) overseer.Config
 ---@field strategy? string Default task strategy
 ---@field templates? string[] Template modules to load
 ---@field auto_detect_success_color? boolean
@@ -19,7 +19,7 @@
 ---@field template_cache_threshold? integer Cache template provider results if the provider takes longer than this to run. Time is in ms. Set to 0 to disable caching.
 ---@field log? table[]
 
----@class overseer.ConfigTaskList
+---@class (exact) overseer.ConfigTaskList
 ---@field default_detail? 1|2|3 Default detail level for tasks. Can be 1-3.
 ---@field max_width? number|number[] Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%). min_width and max_width can be a single value or a list of mixed integer/float types. max_width = {100, 0.2} means "the lesser of 100 columns or 20% of total"
 ---@field min_width? number|number[] min_width = {40, 0.1} means "the greater of 40 columns or 10% of total"
@@ -31,7 +31,7 @@
 ---@field direction? string Default direction. Can be "left", "right", or "bottom"
 ---@field bindings? table<string, string> Set keymap to false to remove default behavior
 
----@class overseer.ConfigFloatWin
+---@class (exact) overseer.ConfigFloatWin
 ---@field border? string|table
 ---@field zindex? integer
 ---@field min_width? number|number[]
@@ -40,12 +40,12 @@
 ---@field max_height? number|number[]
 ---@field win_opts? table<string, any>
 
----@class overseer.ConfigTaskWin
+---@class (exact) overseer.ConfigTaskWin
 ---@field border? string|table
 ---@field padding? integer
 ---@field win_opts? table<string, any>
 
----@class overseer.ConfigBundles
+---@class (exact) overseer.ConfigBundles
 ---@field save_task_opts? table When saving a bundle with OverseerSaveBundle or save_task_bundle(), filter the tasks with these options (passed to list_tasks())
 ---@field autostart_on_load? boolean Autostart tasks when they are loaded from a bundle
 

--- a/lua/overseer/window.lua
+++ b/lua/overseer/window.lua
@@ -74,9 +74,10 @@ M.is_open = function()
 end
 
 ---@class overseer.WindowOpts
----@field enter nil|boolean
----@field direction nil|"left"|"right"|"bottom"
----@field winid nil|integer Use this existing window instead of opening a new window
+---@field enter? boolean
+---@field direction? "left"|"right"|"bottom"
+---@field winid? integer Use this existing window instead of opening a new window
+---@field focus_task_id? integer After opening, focus this task
 
 ---@param opts? overseer.WindowOpts
 M.open = function(opts)
@@ -99,6 +100,11 @@ M.open = function(opts)
   end
   if opts.enter then
     vim.api.nvim_set_current_win(winid)
+  end
+  if opts.focus_task_id then
+    local sidebar = require("overseer.task_list.sidebar")
+    local sb = sidebar.get_or_create()
+    sb:focus_task_id(opts.focus_task_id)
   end
 end
 

--- a/lua/overseer/window.lua
+++ b/lua/overseer/window.lua
@@ -1,42 +1,9 @@
+local TaskView = require("overseer.task_view")
 local config = require("overseer.config")
 local layout = require("overseer.layout")
 local task_list = require("overseer.task_list")
 local util = require("overseer.util")
 local M = {}
-
-local _winclosed_autocmd
-local function watch_for_win_closed()
-  if _winclosed_autocmd then
-    return
-  end
-  _winclosed_autocmd = vim.api.nvim_create_autocmd("WinClosed", {
-    desc = "Close overseer output window when task list is closed",
-    callback = function(args)
-      local winid = tonumber(args.match)
-      local output_win = vim.w[winid].overseer_output_win
-      if output_win and vim.api.nvim_win_is_valid(output_win) then
-        vim.api.nvim_win_close(output_win, true)
-      end
-    end,
-  })
-end
-
-local min_win_opts = {
-  number = false,
-  relativenumber = false,
-  cursorline = false,
-  cursorcolumn = false,
-  foldcolumn = "0",
-  signcolumn = "no",
-  spell = false,
-  list = false,
-}
----@param winid integer
-local function set_minimal_win_opts(winid)
-  for k, v in pairs(min_win_opts) do
-    vim.api.nvim_set_option_value(k, v, { scope = "local", win = winid })
-  end
-end
 
 ---@param direction "left"|"right"|"bottom"
 ---@param existing_win integer
@@ -56,22 +23,14 @@ local function create_overseer_window(direction, existing_win)
 
   -- create the output window if we're opening on the bottom
   if direction == "bottom" then
-    local output_win = vim.w.overseer_output_win
-    if not output_win or not vim.api.nvim_win_is_valid(output_win) then
-      vim.cmd.split({ mods = { vertical = true, noautocmd = true, split = "belowright" } })
-      output_win = vim.api.nvim_get_current_win()
-    end
-    local last_task = task_list.list_tasks({ recent_first = true })[1]
-    local outbuf = last_task and last_task:get_bufnr()
-    if not outbuf or not vim.api.nvim_buf_is_valid(outbuf) then
-      outbuf = vim.api.nvim_create_buf(false, true)
-      vim.bo[outbuf].bufhidden = "wipe"
-    end
-    util.go_buf_no_au(outbuf)
-    set_minimal_win_opts(0)
+    vim.cmd.split({ mods = { vertical = true, noautocmd = true, split = "belowright" } })
+    TaskView.new(0, {
+      close_on_list_close = true,
+      select = function(self, tasks, task_under_cursor)
+        return task_under_cursor or tasks[1]
+      end,
+    })
     util.go_win_no_au(winid)
-    vim.w.overseer_output_win = output_win
-    watch_for_win_closed()
   end
 
   util.go_buf_no_au(bufnr)
@@ -128,6 +87,15 @@ M.open = function(opts)
   local winid = M.get_win_id()
   if winid == nil then
     winid = create_overseer_window(opts.direction, opts.winid)
+    vim.api.nvim_create_autocmd("WinClosed", {
+      desc = "Watch for Overseer task list window close",
+      pattern = tostring(winid),
+      nested = true,
+      once = true,
+      callback = function()
+        vim.api.nvim_exec_autocmds("User", { pattern = "OverseerListClose", modeline = false })
+      end,
+    })
   end
   if opts.enter then
     vim.api.nvim_set_current_win(winid)


### PR DESCRIPTION
~~This new API is used internally by the floating preview window (when previewing a task in the list) and by the side-by-side preview window when overseer is opened in the bottom alignment (`:OverseerOpen bottom`).~~

Refactored to keep the new API internal, but add a `open_output` component that will open the task output under various conditions.

Incidentally fixes #298
