### PR TITLE
doc: fix docstring for `bidnings` where `rhs` can be `false`

### DIFF
--- a/lua/overseer/binding_util.lua
+++ b/lua/overseer/binding_util.lua
@@ -20,7 +20,7 @@ end
 
 ---@param bufnr number
 ---@param mode string
----@param bindings table<string, string>
+---@param bindings table<string, string|false>
 ---@param prefix string
 M.create_bindings_to_plug = function(bufnr, mode, bindings, prefix)
   local maps

--- a/lua/overseer/types.lua
+++ b/lua/overseer/types.lua
@@ -29,7 +29,7 @@
 ---@field height? number
 ---@field separator? string String that separates tasks
 ---@field direction? string Default direction. Can be "left", "right", or "bottom"
----@field bindings? table<string, string> Set keymap to false to remove default behavior
+---@field bindings? table<string, string|false> Set keymap to false to remove default behavior
 
 ---@class (exact) overseer.ConfigFloatWin
 ---@field border? string|table


### PR DESCRIPTION
The right hand side of bindings can be `false` to disable core bindings. This resolves that in the type definitions