### PR TITLE
fix: don't warn on user defined vscode variables (#324)

### DIFF
--- a/lua/overseer/template/vscode/variables.lua
+++ b/lua/overseer/template/vscode/variables.lua
@@ -125,8 +125,7 @@ M.replace_vars = function(str, params, precalculated_vars)
       -- TODO does not support ${workspacefolder:VALUE}
       -- TODO does not support ${config:VALUE}
       -- TODO does not support ${command:VALUE}
-      local unsupported = { "workspacefolder", "config", "command" }
-      if vim.tbl_contains(unsupported, name) then
+      if name == "workspacefolder" or name == "config" or name == "command" then
         log:warn("Unsupported VS Code variable: %s", fullname)
       end
       return fullname

--- a/lua/overseer/template/vscode/variables.lua
+++ b/lua/overseer/template/vscode/variables.lua
@@ -76,9 +76,6 @@ M.replace_vars = function(str, params, precalculated_vars)
     if precalculated_vars and precalculated_vars[name] then
       return precalculated_vars[name]
     end
-    -- TODO does not support ${workspacefolder:VALUE}
-    -- TODO does not support ${config:VALUE}
-    -- TODO does not support ${command:VALUE}
     if name == "userHome" then
       return assert(vim.loop.os_homedir())
     elseif name == "workspaceFolder" then
@@ -125,7 +122,13 @@ M.replace_vars = function(str, params, precalculated_vars)
       else
         fullname = string.format("${%s}", name)
       end
-      log:warn("Unsupported VS Code variable: %s", fullname)
+      -- TODO does not support ${workspacefolder:VALUE}
+      -- TODO does not support ${config:VALUE}
+      -- TODO does not support ${command:VALUE}
+      local unsupported = { "workspacefolder", "config", "command" }
+      if vim.tbl_contains(unsupported, name) then
+        log:warn("Unsupported VS Code variable: %s", fullname)
+      end
       return fullname
     end
   end)


### PR DESCRIPTION
Added a whitelist for the VSCode task's variables which are unsupported by us. 
Now it warns only if variable is in whitelist.
I also moved the TODO comments closer to the whitelist.