### PR TITLE
fix: vscode task hide option was not set correctly

### DIFF
--- a/lua/overseer/template/vscode/init.lua
+++ b/lua/overseer/template/vscode/init.lua
@@ -253,6 +253,9 @@ local function convert_vscode_task(defn, precalculated_vars)
       end
     end
   end
+  if defn.hide then
+    tmpl.hide = true
+  end
   if defn.dependsOn then
     if type(defn.dependsOn) == "string" then
       defn.dependsOn = { defn.dependsOn }
@@ -296,9 +299,6 @@ local function convert_vscode_task(defn, precalculated_vars)
       defn.label or defn.name or defn.command
     )
     return nil
-  end
-  if defn.hide then
-    tmpl.hide = true
   end
 
   -- NOTE: we intentionally do nothing with defn.runOptions.


### PR DESCRIPTION
If you had a VSCode task which you wanted hidden from the tasks list, but this task depended on another, like the second task:
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "Build",
            "type": "shell",
            "command": "gcc main.c",
            "hide": true,
        },
        {
            "label": "Callgrind",
            "type": "shell",
            "hide": true,
            "command": "colorgrind",
            "args": [
                "--tool=callgrind",
                "--callgrind-out-file=cg.out",
                "./main"
            ],
            "dependsOn": "Build"
        },
        {
            "label": "Kcachegrind",
            "type": "shell",
            "command": "kcachegrind cg.out",
            "dependsOn": "Callgrind",
        }
    ]
}
```
only the "Build" task would be hidden, because of incorrect logic (which I actually introduced in b04b0b105c07b4f02b3073ea3a98d6eca90bf152, I'm sorry).

I moved the check to set the hide option in the template above the multiple "return" statement and tested it now works.