### PR TITLE
fix: use the default toggleterm direction by default

### DIFF
--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -28,7 +28,7 @@ function ToggleTermStrategy.new(opts)
   opts = vim.tbl_extend("keep", opts or {}, {
     use_shell = false,
     size = nil,
-    direction = "float",
+    direction = nil,
     highlights = nil,
     auto_scroll = nil,
     close_on_exit = false,


### PR DESCRIPTION
I found that https://github.com/stevearc/overseer.nvim/commit/1f5f271e00b82ced6a30ae5ad6dbe7d1104e5980 changed the toggleterm direction to `"float"` if users do not set them manually, reason not explained.

After a series of improvements for toggleterm be applied, this change is finally caused when starting a new task, the opening toggleterm will be `"float"`, even if the user prefers to keep it the default value of toggleterm.

For example, even if I prefer using a horizontal direction in toggleterm, and not setting the direction of toggleterm strategy in overseer, the terminal overseer opened will be `"float"`.