### PR TITLE
fix: pass config file dir as cwd for cargo-make and deno template

### DIFF
--- a/lua/overseer/template/cargo-make.lua
+++ b/lua/overseer/template/cargo-make.lua
@@ -49,6 +49,7 @@ return {
       cb(ret)
       return
     end
+    local cargo_make_file_dir = vim.fs.dirname(cargo_make_file)
 
     local data = files.read_file(cargo_make_file)
     if not data then
@@ -65,7 +66,7 @@ return {
           overseer.wrap_template(
             tmpl,
             { name = string.format("cargo-make %s", task_name) },
-            { args = { task_name } }
+            { args = { task_name }, cwd = cargo_make_file_dir }
           )
         )
       end

--- a/lua/overseer/template/deno.lua
+++ b/lua/overseer/template/deno.lua
@@ -40,6 +40,7 @@ return {
   },
   generator = function(opts, cb)
     local package = get_deno_file(opts)
+    local package_dir = vim.fs.dirname(package)
     local data = files.load_json_file(package)
     local ret = {}
     local tasks = data.tasks
@@ -50,7 +51,7 @@ return {
           overseer.wrap_template(
             tmpl,
             { name = string.format("deno %s", k) },
-            { args = { "task", k } }
+            { args = { "task", k }, cwd = package_dir }
           )
         )
       end


### PR DESCRIPTION
I found that some templates fail to execute if the configuration file is deeper than root because cwd is not set.

This PR fixes it for `deno` and `cargo-make` template. Other templates such as `composer` and `tox` seem to have the same problem, but I don't have those environments and couldn't test with them, so I didn't include them in this PR for now.