### PR TITLE
cmp completion: allow more patterns

### DIFF
--- a/lua/cmp_overseer/init.lua
+++ b/lua/cmp_overseer/init.lua
@@ -13,7 +13,7 @@ source.get_position_encoding_kind = function()
 end
 
 function source:get_keyword_pattern()
-  return [[\w*]]
+  return [[\S*]]
 end
 
 function source:complete(request, callback)


### PR DESCRIPTION
Relax the patterns that may trigger a cmp completion. \w was [a-zA-Z0-9_]. This didn't allow for "-" for instance. \S is everything but whitespace characters.

In my case I had strings containing `-` and the completion wouldn't work when I'd reach the `-` character.