### PR TITLE
form parse_value: more robust against input

### DIFF
--- a/lua/overseer/form/utils.lua
+++ b/lua/overseer/form/utils.lua
@@ -207,12 +207,12 @@ M.parse_value = function(schema, value)
     end
     return true, ret
   elseif schema.type == "enum" then
-    local key = "^" .. value:lower()
+    local key = value:lower()
     local best
     for _, v in ipairs(schema.choices) do
       if v == value then
         return true, v
-      elseif v:lower():match(key) then
+      elseif vim.startswith(v:lower(), key) then
         best = v
       end
     end


### PR DESCRIPTION
the input may contain regex-special characters, for instance '%'. This function used to crash on strings containing '%'. Since we intended to do a substring comparison, just do that (otherwise we'd have to escape the regex characters in the string).