### PR TITLE
fix: exit for fish shell

### DIFF
--- a/lua/overseer/strategy/toggleterm.lua
+++ b/lua/overseer/strategy/toggleterm.lua
@@ -96,7 +96,7 @@ function ToggleTermStrategy:start(task)
 
       if self.opts.use_shell then
         t:send(cmd)
-        t:send("exit $?")
+        t:send("exit " .. (vim.o.shell:find("fish") and "$status" or "$?"))
       end
     end,
     on_stdout = function(t, job_id, d)


### PR DESCRIPTION
Using `fish` with `use_shell`  generate the following error:
```bash
fish: $? is not the exit status. In fish, please use $status.
```

This quick fix handle exit for fish, let me know if you prefer to add a function in `shell.lua`