### PR TITLE
feat: support bun.lock

### DIFF
--- a/lua/overseer/template/npm.lua
+++ b/lua/overseer/template/npm.lua
@@ -1,11 +1,13 @@
 local files = require("overseer.files")
 local overseer = require("overseer")
+local util = require("overseer.util")
 
-local lockfiles = {
-  npm = "package-lock.json",
-  pnpm = "pnpm-lock.yaml",
-  yarn = "yarn.lock",
-  bun = "bun.lockb",
+---@type table<string, string[]>
+local mgr_lockfiles = {
+  npm = { "package-lock.json" },
+  pnpm = { "pnpm-lock.yaml" },
+  yarn = { "yarn.lock" },
+  bun = { "bun.lockb", "bun.lock" },
 }
 
 ---@type overseer.TemplateFileDefinition
@@ -68,8 +70,12 @@ end
 
 local function pick_package_manager(package_file)
   local package_dir = vim.fs.dirname(package_file)
-  for mgr, lockfile in pairs(lockfiles) do
-    if files.exists(files.join(package_dir, lockfile)) then
+  for mgr, lockfiles in pairs(mgr_lockfiles) do
+    if
+      util.list_any(lockfiles, function(lockfile)
+        return files.exists(files.join(package_dir, lockfile))
+      end)
+    then
       return mgr
     end
   end

--- a/lua/overseer/template/vscode/provider/npm.lua
+++ b/lua/overseer/template/vscode/provider/npm.lua
@@ -1,16 +1,20 @@
 local files = require("overseer.files")
+local util = require("overseer.util")
 local M = {}
 
-local lockfiles = {
-  npm = "package-lock.json",
-  pnpm = "pnpm-lock.yaml",
-  yarn = "yarn.lock",
-  bun = "bun.lockb",
+---@type table<string, string[]>
+local mgr_lockfiles = {
+  npm = { "package-lock.json" },
+  pnpm = { "pnpm-lock.yaml" },
+  yarn = { "yarn.lock" },
+  bun = { "bun.lockb", "bun.lock" },
 }
 
 local function pick_package_manager()
-  for mgr, lockfile in pairs(lockfiles) do
-    if files.exists(lockfile) then
+  for mgr, lockfiles in pairs(mgr_lockfiles) do
+    if util.list_any(lockfiles, function(lockfile)
+      return files.exists(lockfile)
+    end) then
       return mgr
     end
   end


### PR DESCRIPTION
Bun will implement a text-based lockfile format in the future: [`bun.lock`](https://github.com/oven-sh/bun/issues/11863). This PR supports detecting `bun` as the command to use for running scripts defined in `package.json` by searching for `bun.lockb` and `bun.lock`, both of which will continue to be supported for a while.