### PR TITLE
Dispose of pre-existing tasks before loading in tasks from resession

### DIFF
--- a/lua/resession/extensions/overseer.lua
+++ b/lua/resession/extensions/overseer.lua
@@ -21,6 +21,14 @@ end
 M.on_load = function(data)
   local overseer = require("overseer")
   local config = require("overseer.config")
+  local task_list = require("overseer.task_list")
+  while true do
+    local task = task_list.get_by_index(1)
+    if task == nil then
+      break
+    end
+    task:dispose(true)
+  end
   for _, params in ipairs(data) do
     local task = overseer.new_task(params)
     if config.bundles.autostart_on_load then


### PR DESCRIPTION
Disposes of all tasks before loading in tasks from resession. May want to be placed behind an configuration option (I'm happy to implement that if you'd like), but this functionality seems far more sane to me than how it currently works - I don't see why you'd want to preserve pre-existing tasks when switching projects and loading in the tasks for that project.