### PR TITLE
fix: number column randomly appears when opening output

### DIFF
--- a/lua/overseer/task.lua
+++ b/lua/overseer/task.lua
@@ -451,13 +451,13 @@ function Task:open_output(direction)
     util.scroll_to_end(winid)
   elseif direction == "tab" then
     vim.cmd.tabnew()
-    util.set_term_window_opts()
     vim.api.nvim_win_set_buf(0, bufnr)
+    util.set_term_window_opts()
     util.scroll_to_end(0)
   elseif direction == "vertical" then
     vim.cmd.vsplit()
-    util.set_term_window_opts()
     vim.api.nvim_win_set_buf(0, bufnr)
+    util.set_term_window_opts()
     util.scroll_to_end(0)
   elseif direction == "horizontal" then
     -- If we're currently in the task list, open a split in the nearest other window
@@ -470,8 +470,8 @@ function Task:open_output(direction)
       end
     end
     vim.cmd.split()
-    util.set_term_window_opts()
     vim.api.nvim_win_set_buf(0, bufnr)
+    util.set_term_window_opts()
     util.scroll_to_end(0)
   else
     vim.cmd.normal({ args = { "m'" }, bang = true })


### PR DESCRIPTION
The problem doesn't always happen. I don't know what is the root cause.

Trying to move 'set local option' after 'set buffer to window'. It works.