### PR TITLE
Delete task bundle on save if no tasks and on_conflict=overwrite

### DIFF
--- a/lua/overseer/task_bundle.lua
+++ b/lua/overseer/task_bundle.lua
@@ -150,6 +150,9 @@ M.save_task_bundle = function(name, tasks, opts)
       end, task_list.list_tasks(config.bundles.save_task_opts))
     end
     if vim.tbl_isempty(serialized) then
+      if opts.on_conflict == "overwrite" then
+        M.delete_task_bundle(name)
+      end
       return
     end
     local filepath = files.join(get_bundle_dir(), filename)

--- a/lua/overseer/task_bundle.lua
+++ b/lua/overseer/task_bundle.lua
@@ -151,7 +151,7 @@ M.save_task_bundle = function(name, tasks, opts)
     end
     if vim.tbl_isempty(serialized) then
       if opts.on_conflict == "overwrite" then
-        M.delete_task_bundle(name)
+        M.delete_task_bundle(name, { ignore_missing = true })
       end
       return
     end
@@ -208,11 +208,19 @@ M.save_task_bundle = function(name, tasks, opts)
 end
 
 ---@param name? string
-M.delete_task_bundle = function(name)
+---@param opts? {ignore_missing?: boolean}
+M.delete_task_bundle = function(name, opts)
+  vim.validate({
+    name = { name, "s", true },
+    opts = { opts, "t", true },
+  })
+  opts = opts or {}
   if name then
     local filename = string.format("%s.bundle.json", name)
     if not files.delete_file(files.join(get_bundle_dir(), filename)) then
-      vim.notify(string.format("No task bundle at %s", filename))
+      if not opts.ignore_missing then
+        vim.notify(string.format("No task bundle at %s", filename))
+      end
     end
   else
     local tasks = M.list_task_bundles()


### PR DESCRIPTION
Currently, the `save_task_bundle` function does not delete the previous bundle if there are no tasks to save. This led to an issue where I expected no bundles to load on startup, and instead,  bundles from old sessions were loaded when the last session had no tasks to save.

This PR introduces a check to see if on_conflict is set to override (This made the most sense to me but but a new configuration option works too). If so, it calls delete_task_bundle when it detects that there are no tasks to save.