### PR TITLE
fix: compound tasks run all tasks

### DIFF
--- a/lua/overseer/strategy/orchestrator.lua
+++ b/lua/overseer/strategy/orchestrator.lua
@@ -59,7 +59,7 @@ function OrchestratorStrategy.new(opts)
   -- Convert it to each entry being a list of task definitions.
   local task_defns = {}
   for i, v in ipairs(opts.tasks) do
-    if type(v) == "table" and (vim.tbl_isempty(v) or (islist(v) and type(v[1]) == "table")) then
+    if type(v) == "table" and (vim.tbl_isempty(v) or islist(v)) then
       task_defns[i] = v
     else
       task_defns[i] = { v }


### PR DESCRIPTION
The orchestrator parallel tasks were not working for me. I'm using neovim nightly if thats related, but when I run the vscode compound tasks in this repo only the first task runs. I noticed that the orchestrator strategy seems to take in "task names" just fine so I simply removed the check if the task definition is a table when converting the tasks to a list of a list.
