### PR TITLE
fix toggle task list display

### DIFF
--- a/lua/overseer/component/display_duration.lua
+++ b/lua/overseer/component/display_duration.lua
@@ -39,6 +39,9 @@ local comp = {
       end,
       on_complete = function(self)
         self.duration = os.time() - self.start_time
+        if timer then
+          timer:stop()
+        end
       end,
       render = function(self, task, lines, highlights, detail)
         if detail < params.detail_level or (not self.duration and not self.start_time) then

--- a/lua/overseer/task_view.lua
+++ b/lua/overseer/task_view.lua
@@ -113,7 +113,6 @@ function TaskView.new(winid, opts)
       end,
     })
   )
-  self:update()
   return self
 end
 


### PR DESCRIPTION
When toggling display task list, it will only be displayed at the end of a large number of blank lines, and will not correctly display the effect of executing `util.terminal_tail_hack()`. 
![image](https://github.com/user-attachments/assets/792e7cbc-f194-419a-95da-621e36a8ff52)
The reason is that the execution order is wrong. The solution is to delay setting the buffer.