### PR TITLE
Fix escaping issue for shell commands

### DIFF
--- a/lua/overseer/shell.lua
+++ b/lua/overseer/shell.lua
@@ -182,7 +182,6 @@ M.escape_cmd = function(cmd, method, shell)
   local config = get_config_for_shell(shell)
 
   local pieces = {}
-  local cmd_quoted = false
   local args_quoted = false
   for i, v in ipairs(cmd) do
     local arg_quote_method
@@ -190,12 +189,8 @@ M.escape_cmd = function(cmd, method, shell)
       arg_quote_method = v.quoting
       v = v.value
     end
-    if needs_quote(v, config) then
-      if i == 1 then
-        cmd_quoted = true
-      else
-        args_quoted = true
-      end
+    if i ~= 1 and needs_quote(v, config) then
+      args_quoted = true
       local escaped = escape(v, arg_quote_method or method, config)
       table.insert(pieces, escaped)
     else
@@ -205,12 +200,12 @@ M.escape_cmd = function(cmd, method, shell)
 
   local str_cmd = table.concat(pieces, " ")
   local norm_shell = M.normalize_shell_name(shell)
-  if norm_shell == "powershell" and cmd_quoted then
+  if norm_shell == "powershell" then
     str_cmd = "& " .. str_cmd
-  elseif norm_shell == "cmd" and cmd_quoted and args_quoted then
+  elseif norm_shell == "cmd" and args_quoted then
     str_cmd = wrap(str_cmd, '"')
   end
-  return str_cmd, cmd_quoted or args_quoted
+  return str_cmd, args_quoted
 end
 
 return M


### PR DESCRIPTION
I am using `overseer.nvim` in conjunction with `cmake-tools.nvim`.
In `cmake-tools` I defined a task as 
```lua
{       
  cmake_command = "source /home/ubuntu/setup.sh && cmake", -- I am doing cross compilation and need specific $PATH and such
  cmake_generate_options = { "-DCMAKE_EXPORT_COMPILE_COMMANDS=1", "-GNinja", " -DCMAKE_C_COMPILER_LAUNCHER=ccache", "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" }
}
```

from which `cmake-tasks` constructs an `overseer` task, so far so good. However, the following command gets escaped by overseer, and ends up being sent to the shell (bash) as

```
'source /home/ubuntu/setup.sh && cmake' -B /home/arnaud/devel/fotowall/build/Debug -S . -D CMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -GNinja
```

which obviously does not work: the command is escaped out between single quotes `'...'`.

```
FAILURE: 'source /home/ubuntu/setup.sh && cmake' -B /home/arnaud/devel/fotowall/build/Debug -S . -D CMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -GNinja
out: zsh:1: no such file or directory: source /home/ubuntu/setup.sh && cmake
```

A simple way to simulate this failure is to run `bash -c "'echo test1' && echo test2"` in a terminal, which gives `bash: line 1: echo test1: command not found`

The patch in this PR removes escaping of the command, and leaves it for the arguments. This works in this case, but I am unsure if it might break other use cases.

