### PR TITLE
fix: silence cd output during utils.run_in_cwd().

### DIFF
--- a/lua/overseer/util.lua
+++ b/lua/overseer/util.lua
@@ -653,7 +653,7 @@ end
 ---@param callback fun()
 M.run_in_cwd = function(cwd, callback)
   M.run_in_fullscreen_win(nil, function()
-    vim.cmd.lcd({ args = { cwd }, mods = { noautocmd = true } })
+    vim.cmd.lcd({ args = { cwd }, mods = { silent = true, noautocmd = true } })
     callback()
   end)
 end


### PR DESCRIPTION
This PR attempt to fix #404 by adding the `silent = true` option to the `vim.fn.lcd()` call inside `utils.run_in_cwd()`.