### PR TITLE
Add `Restart` binding

### DIFF
--- a/lua/overseer/task_list/bindings.lua
+++ b/lua/overseer/task_list/bindings.lua
@@ -151,6 +151,13 @@ M = {
     end,
   },
   {
+    desc = "Restart task",
+    plug = "<Plug>OverseerTask:Restart",
+    rhs = function(sidebar)
+      sidebar:run_action("restart")
+    end,
+  },
+  {
     desc = "Stop task",
     plug = "<Plug>OverseerTask:Stop",
     rhs = function(sidebar)


### PR DESCRIPTION
I'd like to be able to restart a task in the task list with a single keystroke. If there's a better way to make this happen, let me know!