### PR TITLE
fix: set diagnostic code in on_result_diagnostics

### DIFF
--- a/lua/overseer/component/on_result_diagnostics.lua
+++ b/lua/overseer/component/on_result_diagnostics.lua
@@ -81,6 +81,7 @@ local comp = {
               col = item.col or 0,
               end_col = item.end_col,
               source = task.name,
+              code = item.code,
             })
           end
           local bufnr = vim.fn.bufadd(filename)


### PR DESCRIPTION
## Description

Fixes #429. 

This PR sets the diagnostic code on result diagnostic items sent by the `on_result_diagnostics` component. Please see #429 for details and for a minimal setup.

## Before
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/9e42c124-0beb-40b6-9533-3788f65bdcb8" />

## After
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/333a8570-7ce3-4b34-bb60-5265a5dd46c5" />

Note the error code `(arg-type)`.