### PR TITLE
doc: fix recipe for async `:Make`

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -95,19 +95,31 @@ vim.api.nvim_create_user_command("Make", function(params)
   if num_subs == 0 then
     cmd = cmd .. " " .. params.args
   end
-  local task = require("overseer").new_task({
+  local winnr = vim.fn.win_getid()
+  local bufnr = vim.api.nvim_win_get_buf(winnr)
+  local efm = vim.api.nvim_get_option_value(
+    "errorformat",
+    { scope = "local", buf = bufnr }
+  )
+  local task = require("overseer").new_task {
     cmd = vim.fn.expandcmd(cmd),
     components = {
-      { "on_output_quickfix", open = not params.bang, open_height = 8 },
+      {
+        "on_output_quickfix",
+        open = not params.bang,
+        open_height = 8,
+        errorformat = efm,
+      },
       "default",
     },
-  })
+  }
   task:start()
 end, {
   desc = "Run your makeprg as an Overseer task",
   nargs = "*",
   bang = true,
 })
+)
 ```
 
 ## Asynchronous :Grep command


### PR DESCRIPTION
## Using recipe before:

<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/0464585b-fcfa-47ee-a198-ebfdf4caa412" />

QuickFix  doesn't understand what is the place ( I check via `:cnext` ), so parsing clearly does not work.

## Using new recipe:

<img width="1918" height="1036" alt="image" src="https://github.com/user-attachments/assets/8547c314-3235-4a8d-9eb9-7d9519b5ca79" />

Solution heavily depends on solution from https://phelipetls.github.io/posts/async-make-in-nvim-with-lua/ and the fact that Neovim somehow understand by itself that if file is `*.rs` , then compiler is `cargo` and therefore sets corresponding `errorformat` .