### PR TITLE
Add support for devenv tasks

### DIFF
--- a/lua/overseer/template/devenv.lua
+++ b/lua/overseer/template/devenv.lua
@@ -1,24 +1,7 @@
-local json = require("overseer.json")
-local log = require("overseer.log")
 local overseer = require("overseer")
 
----@type overseer.TemplateFileDefinition
-local tmpl = {
-  priority = 60,
-  params = {
-    args = { type = "list", delimiter = " " },
-    cwd = { optional = true },
-  },
-  builder = function(params)
-    local cmd = { "devenv" }
-    return {
-      args = params.args,
-      cmd = cmd,
-      cwd = params.cwd,
-    }
-  end,
-}
-
+---@param opts overseer.SearchParams
+---@return nil|string
 local function get_devenv_file(opts)
   local devenv_nix = { "devenv.nix" }
   return vim.fs.find(devenv_nix, { upward = true, type = "file", path = opts.dir })[1]
@@ -28,61 +11,41 @@ return {
   cache_key = function(opts)
     return get_devenv_file(opts)
   end,
-  condition = {
-    callback = function(opts)
-      if vim.fn.executable("devenv") == 0 then
-        return false, "executable devenv not found"
-      end
-      if not get_devenv_file(opts) then
-        return false, "No devenv.nix file found"
-      end
-      return true
-    end,
-  },
   generator = function(opts, cb)
+    if vim.fn.executable("devenv") == 0 then
+      return 'Command "devenv" not found'
+    end
     local devenv = get_devenv_file(opts)
+    if not devenv then
+      return "No devenv.nix file found"
+    end
     local devenv_dir = vim.fs.dirname(devenv)
     local ret = {}
-    local jid = vim.fn.jobstart({
-      "devenv",
-      "shell",
-      "echo $DEVENV_TASKS",
-    }, {
-      cwd = devenv_dir,
-      stdout_buffered = true,
-      on_stdout = vim.schedule_wrap(function(j, output)
-        local ok, data =
-          pcall(vim.json.decode, table.concat(output, "\n"), { luanil = { object = true } })
+    overseer.builtin.system(
+      { "devenv", "shell", "echo $DEVENV_TASKS" },
+      { cwd = devenv_dir, text = true },
+      vim.schedule_wrap(function(out)
+        local ok, data = pcall(vim.json.decode, out.stdout, { luanil = { object = true } })
 
         if not ok then
-          log:error("Devenv taskfile produced invalid json: %s\n%s", data, output)
-          cb(ret)
+          cb(data)
           return
         end
 
-        assert(data)
-
         for _, task in ipairs(data) do
-          table.insert(
-            ret,
-            overseer.wrap_template(
-              tmpl,
-              { name = string.format("devenv %s", task.name) },
-              { args = { "tasks", "run", task.name }, cwd = devenv_dir }
-            )
-          )
+          table.insert(ret, {
+            name = string.format("devenv %s", task.name),
+            builder = function()
+              return {
+                cwd = devenv_dir,
+                cmd = { "devenv", "tasks", "run", task.name },
+              }
+            end,
+          })
         end
 
         cb(ret)
-      end),
-    })
-
-    if jid == 0 then
-      log:error("Passed invalid arguments to 'devenv shell'")
-      cb(ret)
-    elseif jid == -1 then
-      log:error("'devenv' is not executable")
-      cb(ret)
-    end
+      end)
+    )
   end,
 }


### PR DESCRIPTION
This PR adds support for [devenv](https://devenv.sh) [tasks](https://devenv.sh/tasks/#executing-tasks-only-when-files-have-been-modified). Tested locally within devenv/non-devenv projects.

### Implementation

devenv tasks are discovered by running `devenv shell 'echo $DEVENV_TASKS'`, which outputs all configured tasks in JSON format. These tasks are then parsed and made available in overseer.


### Screenshot

<img width="643" height="275" alt="afbeelding" src="https://github.com/user-attachments/assets/56ae5777-a0fc-4834-8f88-359007c7bcb5" />
