### PR TITLE
fix(template/taskfile): send correct target name in generator

### DIFF
--- a/lua/overseer/template/task.lua
+++ b/lua/overseer/template/task.lua
@@ -53,7 +53,7 @@ return {
             desc = target.desc,
             builder = function()
               return {
-                cmd = { "task", target },
+                cmd = { "task", target.name },
                 cwd = cwd,
               }
             end,


### PR DESCRIPTION
when running a task with OverseerRun command I get the following error:

```
|| Error executing vim.schedule lua callback: ...ocal/share/nvim/lazy/overseer.nvim/lua/overseer/task.lua:102: invalid value (table) at index 2 in table for 'concat'
|| stack traceback:
|| 	[C]: in function 'concat'
|| 	...ocal/share/nvim/lazy/overseer.nvim/lua/overseer/task.lua:102: in function 'new'
|| 	.../share/nvim/lazy/overseer.nvim/lua/overseer/template.lua:432: in function 'callback'
|| 	.../share/nvim/lazy/overseer.nvim/lua/overseer/template.lua:382: in function 'build_task_args'
|| 	.../share/nvim/lazy/overseer.nvim/lua/overseer/template.lua:407: in function 'build_task'
|| 	.../share/nvim/lazy/overseer.nvim/lua/overseer/commands.lua:158: in function 'handle_tmpl'
|| 	.../share/nvim/lazy/overseer.nvim/lua/overseer/commands.lua:193: in function 'on_choice'
```

looks like the generator is sending a table instead of a string for the task name. this fixes it