### PR TITLE
fix: removed files.join -> vim.fs.joinpath

### DIFF
--- a/lua/overseer/files.lua
+++ b/lua/overseer/files.lua
@@ -85,7 +85,7 @@ M.get_stdpath_filename = function(stdpath, ...)
       error(dir)
     end
   end
-  return M.join(dir, ...)
+  return vim.fs.joinpath(dir, ...)
 end
 
 ---@param filepath string


### PR DESCRIPTION
the M.join had beend deleted on https://github.com/stevearc/overseer.nvim/commit/596ee9f61e2a96e7f04b7894e43a2433b220934a