### PR TITLE
[DRAFT] [RFC] new option: output.custom_init

### DIFF
--- a/lua/overseer/strategy/jobstart.lua
+++ b/lua/overseer/strategy/jobstart.lua
@@ -173,6 +173,9 @@ function JobstartStrategy:_init_buffer()
       vim.keymap.set("n", lhs, open_input, { buffer = self.bufnr })
     end
   end
+  if self.opts.custom_init then
+    self.opts.custom_init(self.bufnr)
+  end
 end
 
 ---@param task overseer.Task

--- a/lua/overseer/task.lua
+++ b/lua/overseer/task.lua
@@ -109,6 +109,7 @@ function Task.new(opts)
       "jobstart",
       use_terminal = config.output.use_terminal,
       preserve_output = config.output.preserve_output,
+      custom_init = config.output.custom_init,
     }
   end
 


### PR DESCRIPTION
I'd be interested in adding this feature to overseer, but before updating the documentation and doing the whole thing, I'd like your opinion whether you'd want something like that at all.

Let me explain what I would use this feature for. In my neovim config I have this code:
```lua
vim.api.nvim_create_autocmd("TermOpen", {
  pattern = "*",
  callback = function(args)
    vim.keymap.set({'n', 'v'}, 'q', function()
      vim.api.nvim_win_close(vim.api.nvim_get_current_win(), false)
    end, {buffer = true})
  end,
})
```
so, any terminal buffer i can close with `q`. Conveniently, with overseer 1.x, this worked also with "open float" overseer output windows. Very handy. It doesn't work anymore with overseer 2, because TermOpen is not triggered.

I could add an autocmd on BufEnter or BufWinEnter, but that will trigger way more often, not only when the buffer is created, but everytime I switch to it (and for all buffers).

With the change from this PR, I can do...

```lua
    require('overseer').setup{
      output = {
        custom_init = function(bufnr)
          vim.keymap.set({'n', 'v', 't'}, 'q', function()
            vim.api.nvim_win_close(vim.api.nvim_get_current_win(), false)
          end, {buffer = bufnr})
        end,
      },
```

And I get what I want.

A possible alternative could be to try to create the buffer with immediately a buftype=terminal, and then I could maybe tie an autocmd to `BufAdd`, but I didn't try it.

Currently the sequence is:
* BufNew      buftype=nofile
* BufEnter    buftype=terminal
* BufWinEnter buftype=terminal

This PR is only a proof of concept so you can give your opinion on the general idea. If you agree with the approach, I'll update the types, the documentation and so on.