### PR TITLE
npm: add parameterless job

### DIFF
--- a/lua/overseer/template/npm.lua
+++ b/lua/overseer/template/npm.lua
@@ -285,6 +285,15 @@ return {
       end
     end
 
+    table.insert(ret, {
+      name = bin .. " install",
+      builder = function()
+        return {
+          cmd = { bin, "install" },
+          cwd = cwd,
+        }
+      end,
+    })
     return ret
   end,
 }


### PR DESCRIPTION
for instance "yarn" which is a shortcut for "yarn install"

this is meant to restore the following line from the overseer1 npm adapter, which seems to have been lost in the 2.0 migration:
https://github.com/emmanueltouzery/overseer.nvim/blob/mine/lua/overseer/template/npm.lua#L138

