### PR TITLE
fix: prevent visiting node_modules during workspace lookup

### DIFF
--- a/lua/overseer/template/npm.lua
+++ b/lua/overseer/template/npm.lua
@@ -94,7 +94,11 @@ local function resolve_workspace_paths(base_path, workspace_patterns)
 
     for _, match in ipairs(matches) do
       local package_json_path = vim.fs.joinpath(match, "package.json")
-      if vim.uv.fs_stat(package_json_path) and not seen[match] then
+      if
+        not match:match("node_modules")
+        and vim.uv.fs_stat(package_json_path)
+        and not seen[match]
+      then
         table.insert(resolved, match)
         seen[match] = true
       end


### PR DESCRIPTION
Currently, when running `:OverseerRun` in a TypeScript monorepo, during workspaces traversal the plugin also goes into the installed node_modules and checks them. This creates a pretty long freeze while loading tasks and the list that the command outputs looks absolutely abysmal:

<img width="974" height="379" alt="image" src="https://github.com/user-attachments/assets/c4d698e0-25c7-4c3c-835e-395242bba02c" />

This PR prevents looking up node_modules for package.json files, thus improves the list of commands `:OverseerRun` outputs. I'm not sure if that's the best solution, but I tested it and it worked for me. It's unlikely there's going to be an edge-case that someone actually develops or wants to run tasks within `node_modules`, so this hopefully should work.