### PR TITLE
fix(mix): call callback after successfully parsing tasks

### DIFF
--- a/lua/overseer/template/mix.lua
+++ b/lua/overseer/template/mix.lua
@@ -39,6 +39,7 @@ return {
             end,
           })
         end
+        cb(ret)
       end)
     )
   end,


### PR DESCRIPTION
## Summary

The mix template provider was missing the `cb(ret)` call after the for loop that parses `mix help` output. This caused the provider to never complete on success, resulting in a 3-second timeout delay before templates were shown.

## The Bug

In `lua/overseer/template/mix.lua`, the callback `cb` was only called on error (line 29), but never called after successfully building the task list:

```lua
vim.schedule_wrap(function(out)
  if out.code ~= 0 then
    return cb(out.stderr or out.stdout or "Error running 'mix help'")
  end
  for line in vim.gsplit(out.stdout, "\n") do
    -- ... build tasks ...
  end
  -- BUG: cb(ret) was missing here
end)
```

## The Fix

Added `cb(ret)` after the for loop to properly return the parsed tasks.

## Test plan

- [x] Tested on an Elixir/Phoenix project with mix.exs
- [x] Verified mix tasks now appear in `:OverseerRun` without delay
- [x] Verified no regression on error path (missing mix executable)