### PR TITLE
Clean up buffers opened by open_output.lua on reset

### DIFF
--- a/lua/overseer/component/open_output.lua
+++ b/lua/overseer/component/open_output.lua
@@ -119,12 +119,10 @@ return {
       end
 
       methods.on_reset = function()
-        if bufnr then
-          if vim.fn.bufexists(bufnr) == 1 and vim.api.nvim_buf_is_valid(bufnr) then
-            vim.api.nvim_buf_delete(bufnr, { force = true })
-          end
-          bufnr = nil
+        if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+          vim.api.nvim_buf_delete(bufnr, { force = true })
         end
+        bufnr = nil
       end
     end
 

--- a/lua/overseer/component/open_output.lua
+++ b/lua/overseer/component/open_output.lua
@@ -57,6 +57,11 @@ return {
       type = "boolean",
       default = false,
     },
+    close_on_reset = {
+      desc = "Delete the output buffer when the task is reset",
+      type = "boolean",
+      default = false,
+    },
   },
   constructor = function(params)
     -- backwards compatibility
@@ -67,9 +72,10 @@ return {
     end
     ---@type overseer.ComponentSkeleton
     local methods = {}
+    local bufnr
 
     if params.on_start ~= "never" then
-      methods.on_start = function(self, task)
+      methods.on_start = function(_, task)
         if
           params.on_start == "always"
           or (
@@ -83,7 +89,7 @@ return {
     end
 
     if params.on_result ~= "never" then
-      methods.on_result = function(self, task, result)
+      methods.on_result = function(_, task, result)
         if
           params.on_result == "always"
           or (
@@ -96,13 +102,28 @@ return {
     end
 
     if params.on_complete ~= "never" then
-      methods.on_complete = function(self, task, status, result)
+      methods.on_complete = function(_, task, status)
         if
           params.on_complete == "always"
           or (params.on_complete == "success" and status == STATUS.SUCCESS)
           or (params.on_complete == "failure" and status == STATUS.FAILURE)
         then
           open_output(task, params.direction, params.focus)
+        end
+      end
+    end
+
+    if params.close_on_reset then
+      methods.on_exit = function(_, task)
+        bufnr = task:get_bufnr()
+      end
+
+      methods.on_reset = function()
+        if bufnr then
+          if vim.fn.bufexists(bufnr) == 1 and vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+          end
+          bufnr = nil
         end
       end
     end


### PR DESCRIPTION
Obviously I can add a flag to control this but this is very handy when running tasks over and over again.