### PR TITLE
rsession extension does not persist non-default task components added before session save

### DIFF
--- a/lua/resession/extensions/overseer.lua
+++ b/lua/resession/extensions/overseer.lua
@@ -27,6 +27,7 @@ M.on_load = function(data)
   local overseer = require("overseer")
   for _, params in ipairs(data) do
     local task = overseer.new_task(params)
+    task:add_components(params.components)
     if conf.autostart_on_load then
       task:start()
     end


### PR DESCRIPTION
**Fix: Resession extension not persisting non-default task components**

This PR fixes a bug where custom components added to tasks (such as `restart_on_save`) were not being restored when loading a session with the resession extension.

When tasks with custom components were saved and later loaded from a resession session, those components would be lost. For example, if a user added a `restart_on_save` component to a task, after restoring the session, that task would no longer restart on file save.

1. `Task:serialize()` properly saves all serializable components to the `components` field
2. When loading, `overseer.new_task(params)` is called
3. `overseer.new_task()` has special handling for `from_template` tasks that bypasses the normal `Task.new()` flow where components are added
4. As a result, `params.components` containing the serialized custom components was never processed

Added an explicit call to `task:add_components(params.components)` after loading the task on the extension, ensuring all serialized components are properly restored.

closes #507 