### PR TITLE
fix: experimental_wrap_builtins shortly enabled by default

### DIFF
--- a/lua/overseer/init.lua
+++ b/lua/overseer/init.lua
@@ -152,7 +152,6 @@ M.private_setup = function()
   did_setup = true
 
   create_commands()
-  M.wrap_builtins()
   create_highlights()
   local aug = vim.api.nvim_create_augroup("Overseer", {})
   vim.api.nvim_create_autocmd("ColorScheme", {


### PR DESCRIPTION
The old stack trace looked like this
`M.setup() -> M.private_setup() -> M.wrap_builtins()`. `M.private_setup()` does not use any values from the `config` table and calls `M.wrap_builtins()` with its' default arguments (enable=true). This caused the functions `vim.system()` and `vim.fn.jobstart()` to be wrapped, until `M.wrap_builtins(config.experimental_wrap_builtins.enabled)` is called at the end of `M.setup()` (assuming the user did not enable the setting on their own). If `vim.system()` was called in this short timeframe, problems like in https://github.com/stevearc/overseer.nvim/issues/508 would arise.

This commit fixes this problem, by moving `M.wrap_builtins()` entirely into `M.setup()`.