### PR TITLE
fix: guard against deleted buffer in vim.schedule callbacks

### DIFF
--- a/lua/overseer/strategy/system.lua
+++ b/lua/overseer/strategy/system.lua
@@ -109,6 +109,9 @@ function SystemStrategy:start(task)
 
   ---@param data string
   local on_output = vim.schedule_wrap(function(data)
+    if not self.bufnr or not vim.api.nvim_buf_is_valid(self.bufnr) then
+      return
+    end
     -- Update the buffer
     -- Track which wins we will need to scroll
     local trail_wins = {}
@@ -208,6 +211,9 @@ function SystemStrategy:start(task)
     -- The rest of this needs to not happen in a fast event
     vim.schedule(function()
       log.debug("Task %s exited with code %s", task.name, out.code)
+      if not self.bufnr or not vim.api.nvim_buf_is_valid(self.bufnr) then
+        return
+      end
       -- Feed one last line end to flush the output
       on_output("\n")
       vim.bo[self.bufnr].modifiable = true


### PR DESCRIPTION
## Problem

When using the `system` strategy, this error occurs intermittently:

```
vim.schedule callback: ...overseer.nvim/lua/overseer/strategy/system.lua:115:
  Invalid buffer id: 70
...
```

## Root Cause

The `on_output` callback is wrapped with `vim.schedule_wrap`, which defers execution. Between scheduling and execution, the buffer may have been deleted by `reset()` or `dispose()` — a TOCTOU race condition. Same issue in `on_exit`'s `vim.schedule` callback.

## Fix

Add `nvim_buf_is_valid` guards at the top of both deferred callbacks, returning early if the buffer no longer exists.

## Changes

- `lua/overseer/strategy/system.lua`: two guard clauses (+6 lines)

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)