### PR TITLE
fix sidebar previous/next navigation

### DIFF
--- a/lua/overseer/task_list/sidebar.lua
+++ b/lua/overseer/task_list/sidebar.lua
@@ -293,8 +293,8 @@ end
 function Sidebar:jump(direction)
   local lnum = vim.api.nvim_win_get_cursor(0)[1]
   for i, v in ipairs(self.task_lines) do
-    local first_line = v[1]
-    if first_line >= lnum then
+    local first_line, last_line = unpack(v)
+    if lnum >= first_line and lnum <= last_line then
       if direction < 0 and i > 1 then
         local new_lnum = self.task_lines[i - 1][1]
         vim.api.nvim_win_set_cursor(0, { new_lnum, 0 })


### PR DESCRIPTION
example of issue previously:
task_lines {1,7} and {8,10}
lnum is 7
we'll pick the second section and do nothing because the second is the last section. But the cursor is on the first section! So make the section detection more robust.