### PR TITLE
fix(on_output_parse): resolve relative paths against task cwd, not vim's real cwd

### DIFF
--- a/lua/overseer/component/on_output_parse.lua
+++ b/lua/overseer/component/on_output_parse.lua
@@ -2,6 +2,7 @@ local files = require("overseer.files")
 local log = require("overseer.log")
 local parselib = require("overseer.parselib")
 local problem_matcher = require("overseer.vscode.problem_matcher")
+local util = require("overseer.util")
 
 ---@param cwd string
 ---@param result table
@@ -99,18 +100,30 @@ return {
         version = parser.result_version
       end,
       on_output_lines = function(self, task, lines)
-        for _, line in ipairs(lines) do
-          parser:parse(line)
-        end
+        local cwd = params.relative_file_root or task.cwd
+        -- Run this in the context of the task cwd (or relative_file_root) so
+        -- that parsers backed by vim.fn.getqflist() (e.g. errorformat-based
+        -- parsers) resolve relative filenames correctly. getqflist() creates
+        -- a buffer for any matched filename immediately, resolved against
+        -- Neovim's real cwd, so this has to happen before parsing, not just
+        -- when fixing up the result below.
+        util.run_in_cwd(cwd, function()
+          for _, line in ipairs(lines) do
+            parser:parse(line)
+          end
+        end)
         if version ~= parser.result_version then
-          task:set_result(
-            fix_relative_filenames(params.relative_file_root or task.cwd, parser:get_result())
-          )
+          task:set_result(fix_relative_filenames(cwd, parser:get_result()))
           version = parser.result_version
         end
       end,
       on_pre_result = function(self, task)
-        return fix_relative_filenames(params.relative_file_root or task.cwd, parser:get_result())
+        local cwd = params.relative_file_root or task.cwd
+        local result
+        util.run_in_cwd(cwd, function()
+          result = parser:get_result()
+        end)
+        return fix_relative_filenames(cwd, result)
       end,
     }
   end,

--- a/tests/component/on_output_parse_spec.lua
+++ b/tests/component/on_output_parse_spec.lua
@@ -1,0 +1,45 @@
+local component = require("overseer.component")
+
+describe("on_output_parse", function()
+  local root
+
+  before_each(function()
+    root = vim.fn.tempname()
+    vim.fn.mkdir(root, "p")
+  end)
+
+  after_each(function()
+    vim.fn.delete(root, "rf")
+  end)
+
+  it("resolves relative filenames against relative_file_root, not vim's real cwd", function()
+    assert.are_not.same(root, vim.fn.getcwd())
+
+    local comps = component.load(
+      { { "on_output_parse", errorformat = "%f:%l: %m" } },
+      { relative_file_root = root }
+    )
+    local comp = comps[1]
+    -- task.cwd is deliberately different from relative_file_root, and never
+    -- used as a real directory, to prove relative_file_root takes priority.
+    local task = { cwd = "/some/unrelated/task/cwd" }
+
+    comp:on_output_lines(task, { "pkg/foo.go:10: some error" })
+    local result = comp:on_pre_result(task)
+
+    local diag = result.diagnostics[1]
+    assert.are.same(vim.fs.joinpath(root, "pkg/foo.go"), vim.api.nvim_buf_get_name(diag.bufnr))
+  end)
+
+  it("falls back to task.cwd when relative_file_root is not set", function()
+    local comps = component.load({ { "on_output_parse", errorformat = "%f:%l: %m" } }, {})
+    local comp = comps[1]
+    local task = { cwd = root }
+
+    comp:on_output_lines(task, { "pkg/bar.go:5: another error" })
+    local result = comp:on_pre_result(task)
+
+    local diag = result.diagnostics[1]
+    assert.are.same(vim.fs.joinpath(root, "pkg/bar.go"), vim.api.nvim_buf_get_name(diag.bufnr))
+  end)
+end)


### PR DESCRIPTION

vim.fn.getqflist() resolves any %f-matched relative filename into a buffer immediately, against Neovim's actual getcwd() at the time it's called. The errorformat-based parser (parselib.parser_from_errorformat) never scoped this call to task.cwd/relative_file_root, so relative diagnostic paths were silently resolved against whatever Neovim's real cwd happened to be, rather than the task's cwd or a configured relative_file_root override.

fix_relative_filenames only rewrites a plain diag.filename string, which errorformat-parsed items never have (they carry bufnr instead), so it never caught this case either.

Wrap the parser:parse()/parser:get_result() calls in util.run_in_cwd(), mirroring the existing pattern already used for the same getqflist() call in on_output_quickfix.lua.

Regression test in tests/component/on_output_parse_spec.lua fails against the prior behavior (path resolves to vim's real cwd) and passes with this fix.

Fixes #523